### PR TITLE
WIP: DataStreams integration

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 LightXML
 ZipFile
 Missings
+DataStreams

--- a/src/XLSX.jl
+++ b/src/XLSX.jl
@@ -13,5 +13,6 @@ include("read.jl")
 include("workbook.jl")
 include("worksheet.jl")
 include("styles.jl")
+include("datastreams.jl")
 
 end # module XLSX

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -1,0 +1,18 @@
+struct Table
+    ws::Worksheet
+    schema::Data.Schema
+end
+
+function Table(ws::Worksheet)
+    dim = dimension(ws)
+    rows, cols = size(dim)
+    return Table(ws, Data.Schema(collect(Any for i = 1:cols), rows))
+end
+
+Data.schema(source::Table) = source.schema
+Data.accesspattern(::Type{Table}) = Data.RandomAccess
+@inline Data.isdone(::Table, row, col, rows, cols) = row > rows || col > cols
+@inline Data.isdone(table::Table, row, col) = Data.isdone(table, row, col, size(table.schema)...)
+Data.streamtype(::Type{<:Table}, ::Type{Data.Field}) = true
+@inline Data.streamfrom(source::Table, ::Type{Data.Field}, ::T, row, col::Int) = source.ws[CellRef(row, col)]
+


### PR DESCRIPTION
Here's a start, a couple thoughts as I was going thru this:

* I wasn't sure exactly how to get at the table data in a `Worksheet`, but I tried to follow examples and use the worksheet.jl file for reference
* Ideally, we'd have a way to allow the user to specify column headers if they exist in the worksheet (this implementation just streams all data as data)
* If their data doesn't start at A1, can we still use `CellRef`? Ideally, we'd have a way to say, "give me the cell value for row 3, column 4, relative to wherever my datagrid starts on a worksheet". Maybe that already exists?
* Am I right in assuming that cells support random access? (i.e. you can jump to any cell w/o needing to process cells in between). From perusing the code, it seemed so.