### PR TITLE
detect valid xlsx before opening (#34)

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -4,6 +4,21 @@
 @inline get_workbook(ws::Worksheet) :: Workbook = get_xlsxfile(ws).workbook
 @inline get_workbook(xl::XLSXFile) :: Workbook = xl.workbook
 
+function check_for_xlsx_file_format(filepath::AbstractString)
+    @assert isfile(filepath) "File $filepath not found."
+    io = open(filepath, "r")
+    header = Base.read(io, 4)
+    close(io)
+
+    if header == [ 0x50, 0x4b, 0x03, 0x04 ] # valid Zip file header
+        return
+    elseif header == [ 0xd0, 0xcf, 0x11, 0xe0 ] # old XLS file
+        error("$filepath looks like an old XLS file (not XLSX). This package does not support XLS file format.")
+    else
+        error("$filepath is not a valid XLSX file.")
+    end
+end
+
 """
     readxlsx(filepath) :: XLSXFile
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -215,7 +215,7 @@ mutable struct XLSXFile <: MSOfficePackage
     is_writable::Bool # indicates wether this XLSX file can be edited
 
     function XLSXFile(filepath::AbstractString, use_cache::Bool, is_writable::Bool)
-        @assert isfile(filepath) "File $filepath not found."
+        check_for_xlsx_file_format(filepath)
         io = ZipFile.Reader(filepath)
         xl = new(filepath, use_cache, io, true, Dict{String, Bool}(), Dict{String, EzXML.Document}(), Dict{String, Vector{UInt8}}(), EmptyWorkbook(), Vector{Relationship}(), is_writable)
         xl.workbook.package = xl


### PR DESCRIPTION
This checks zip file magic numbers, and also old xls magic numbers, to give a helpful error message when opening non-xlsx files.