### PR TITLE
 replace dirname(@__FILE__) with Pkg.dir("XLSX") for vscode

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -267,7 +267,7 @@ setdata!(ws::Worksheet, ref_str::AbstractString, value) = error("Unsupported dat
 
 Base.setindex!(ws::Worksheet, v, ref) = setdata!(ws, ref, v)
 
-const DEFAULT_EXCEL_TEMPLATE = joinpath(dirname(@__FILE__), "..", "data", "blank.xlsx")
+const DEFAULT_EXCEL_TEMPLATE = joinpath(@__DIR__, "..", "data", "blank.xlsx")
 
 function open_default_template() :: XLSXFile
     @assert isfile(DEFAULT_EXCEL_TEMPLATE) "Couldn't find template file $DEFAULT_EXCEL_TEMPLATE."
@@ -329,7 +329,7 @@ function rename!(ws::Worksheet, name::AbstractString)
     nothing
 end
 
-const FILEPATH_SHEET_TEMPLATE = joinpath(dirname(@__FILE__), "..", "data", "sheet_template.xml")
+const FILEPATH_SHEET_TEMPLATE = joinpath(@__DIR__, "..", "data", "sheet_template.xml")
 
 addsheet!(xl::XLSXFile, name::AbstractString="") :: Worksheet = addsheet!(get_workbook(xl), name)
 

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -5,7 +5,7 @@ import XLSX
 # examples from docstrings
 #
 
-data_directory = joinpath(dirname(@__FILE__), "..", "data")
+data_directory = joinpath(Pkg.dir("XLSX"), "data")
 
 v = XLSX.readdata(joinpath(data_directory, "myfile.xlsx"), "mysheet", "A1:B4")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@
 import XLSX
 using Base.Test, Missings
 
-data_directory = joinpath(dirname(@__FILE__), "..", "data")
+data_directory = joinpath(Pkg.dir("XLSX"), "data")
 
 ef_blank_ptbr_1904 = XLSX.readxlsx(joinpath(data_directory, "blank_ptbr_1904.xlsx"))
 ef_Book1 = XLSX.readxlsx(joinpath(data_directory, "Book1.xlsx"))


### PR DESCRIPTION
julia-vscode don't support @__FILE__ [macro in REPL](https://github.com/JuliaEditorSupport/julia-vscode/issues/394) yet.

This change will make it more convenient to run `runtests.jl` and `examples.jl` in vscode, 