### PR TITLE
Show sheetnames and range information on REPL

### DIFF
--- a/src/workbook.jl
+++ b/src/workbook.jl
@@ -65,7 +65,7 @@ function Base.show(io::IO, xf::XLSXFile)
         rg = s.dimension
         _size = size(rg) |> x -> string(x[1], "x", x[2])
         name = s.name |> x -> length(x) < 20 ? x : x[1:20]*"…"
-        @printf("%21s %-13s %-13s\n", name, _size, rg)
+        @printf(io, "%21s %-13s %-13s\n", name, _size, rg)
     end
 end
 

--- a/src/workbook.jl
+++ b/src/workbook.jl
@@ -54,7 +54,20 @@ end
 @inline getsheet(xl::XLSXFile, sheetname::String) :: Worksheet = getsheet(xl.workbook, sheetname)
 @inline getsheet(xl::XLSXFile, sheet_index::Int) :: Worksheet = getsheet(xl.workbook, sheet_index)
 
-Base.show(io::IO, xf::XLSXFile) = print(io, "XLSXFile(\"$(xf.filepath)\")")
+function Base.show(io::IO, xf::XLSXFile) 
+    wb = xf.workbook
+    print(io, "XLSXFile(\"$(basename(xf.filepath))\") ",
+              "containing $(sheetcount(wb)) Worksheets\n")
+    @printf(io, "%21s %-13s %-13s\n", "sheetname", "size", "range")
+    println(io, "-"^(21+1+13+1+13))
+    
+    for s in wb.sheets
+        rg = s.dimension
+        _size = size(rg) |> x -> string(x[1], "x", x[2])
+        name = s.name |> x -> length(x) < 20 ? x : x[1:20]*"…"
+        @printf("%21s %-13s %-13s\n", name, _size, rg)
+    end
+end
 
 @inline Base.getindex(xl::XLSXFile, i::Integer) = getsheet(xl, i)
 

--- a/src/workbook.jl
+++ b/src/workbook.jl
@@ -64,7 +64,7 @@ function Base.show(io::IO, xf::XLSXFile)
     for s in wb.sheets
         rg = s.dimension
         _size = size(rg) |> x -> string(x[1], "x", x[2])
-        name = s.name |> x -> length(x) < 20 ? x : x[1:20]*"…"
+        name = s.name |> x -> length(x) > 20 ? x[1:20]*"…" : x
         @printf(io, "%21s %-13s %-13s\n", name, _size, rg)
     end
 end

--- a/src/worksheet.jl
+++ b/src/worksheet.jl
@@ -171,8 +171,11 @@ getdata(ws::Worksheet) = getdata(ws, get_dimension(ws))
 Base.getindex(ws::Worksheet, r) = getdata(ws, r)
 Base.getindex(ws::Worksheet, ::Colon) = getdata(ws)
 
-Base.show(io::IO, ws::Worksheet) = print(io, "XLSX.Worksheet: \"$(ws.name)\"")
-
+function Base.show(io::IO, ws::Worksheet) 
+    rg = get_dimension(ws)
+    nrow, ncol = size(rg)
+    @printf(io, "%d×%d %s: [\"%s\"](%s)", nrow, ncol, typeof(ws), ws.name, rg)
+end
 """
     getcell(sheet, ref)
     getcell(filepath, sheet, ref)


### PR DESCRIPTION
pr for #38 

Sheetname length limit for Microsoft Office is `31` but I thought it is unnecessary to reserve 31 spaces for sheetname. So I've truncated sheetname at arbitrary number 20.

the maximum length of "size" is 13(`1048576x16384`) 
and maximum length of "range" is 21('XFD1048575:XFD1048576') but charater length limit for both information is '13'

Because "range" column is positioned at the end, so it wouldn't distort display. Even "range" information text is longer than 13 