### PR TITLE
Added (auto-generated) docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/.DS_Store
+docs/build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ notifications:
 after_success:
   - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("XLSX")); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   - julia -e 'cd(Pkg.dir("XLSX")); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'Pkg.add("Documenter"); cd(Pkg.dir("XLSX")); include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/felipenoris/XLSX.jl.svg?branch=master)](https://travis-ci.org/felipenoris/XLSX.jl)
 [![codecov.io](http://codecov.io/github/felipenoris/XLSX.jl/coverage.svg?branch=master)](http://codecov.io/github/felipenoris/XLSX.jl?branch=master)
 [![XLSX](http://pkg.julialang.org/badges/XLSX_0.6.svg)](http://pkg.julialang.org/?pkg=XLSX&ver=0.6)
-
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://felipenoris.github.io/XLSX.jl/latest)
 Excel file reader/writer coded in pure Julia.
 
 ## Installation
@@ -38,13 +38,13 @@ julia> sh["B2"] # From a sheet, you can access a cell value
 
 julia> sh["A2:B4"] # or a cell range
 3×2 Array{Any,2}:
- 1  "first" 
+ 1  "first"
  2  "second"
  3  "third"
 
 julia> XLSX.readdata("myfile.xlsx", "mysheet", "A2:B4") # shorthand for all above
 3×2 Array{Any,2}:
- 1  "first" 
+ 1  "first"
  2  "second"
  3  "third"
 
@@ -52,12 +52,12 @@ julia> sh[:] # all data inside worksheet's dimension
 4×2 Array{Any,2}:
   "HeaderA"  "HeaderB"
  1           "first"  
- 2           "second" 
+ 2           "second"
  3           "third"
 
 julia> xf["mysheet!A2:B4"] # you can also query values from a file reference
 3×2 Array{Any,2}:
- 1  "first" 
+ 1  "first"
  2  "second"
  3  "third"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,18 @@
+using Documenter, XLSX
+
+makedocs(
+    format = :html,
+    sitename = "XLSX.jl",
+    modules = [XLSX],
+    pages = ["index.md",
+            "api.md"
+             ]
+)
+
+deploydocs(
+    repo = "github.com/felipenoris/XLSX.jl.git",
+    target = "build",
+    julia  = "0.6",
+    deps   = nothing,
+    make   = nothing
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,5 @@
+# API
+
+```@autodocs
+Modules = [XLSX]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,3 @@
+# Tutorial
+
+TODO


### PR DESCRIPTION
Basic docs auto-generated from doc strings. Fixes [#9](https://github.com/felipenoris/XLSX.jl/issues/9)

Todo's:
- [ ] (by Felipe) [https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#SSH-Deploy-Keys-1](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#SSH-Deploy-Keys-1) =>  generate SSH keys  and add to Github and Travis