### PR TITLE
row_index creation in worksheet cache leading to recursion error?

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -190,11 +190,7 @@ function setdata!(ws::Worksheet, cell::Cell)
         sort!(cache.rows_in_cache)
         cache.cells[r] = Dict{Int, Cell}()
 
-        for i in 1:length(cache.rows_in_cache)
-            if cache.rows_in_cache[i] == r
-                cache.row_index[r] = i
-            end
-        end
+        cache.row_index = Dict{Int, Int}(cache.rows_in_cache[i] => i for i in 1:length(cache.rows_in_cache))
     end
     cache.cells[r][c] = cell
 


### PR DESCRIPTION
This PR is primarily a bug report, secondly a suggested solution.
I had a problem when writing to new rows above already-existing rows:

**MWE1**
```
XLSX.openxlsx("test.xlsx", mode="w") do xf
    xf[1]["A2"] = 5
    xf[1]["A1"] = 7
end
```
This causes Julia to not terminate and start to allocate more and more memory.

The problem seems to be that, in `update_worksheets_xml!`, the iterator in `for r in eachrow(sheet)` never terminates. This seems to be due to [the assumption the cache iterator makes](https://github.com/felipenoris/XLSX.jl/blob/a85d44e74ca62906ab49119d63bd5bc247bde327/src/stream.jl#L229) that the `row_index` is monotone increasing. This is not necessarily the case: if the higher row is created last, both `row_index` entries can point to the same row, leading to an endless recursion. The `row_index` is dependent on the order in which the cells are written to, is that intentional?

**MWE2**
```
xf = XLSX.open_empty_template()
ws = XLSX.getsheet(XLSX.get_workbook(xf),1)
xf[1]["A2"] = 5
xf[1]["A1"] = 7
println(ws.cache.row_index)
```

If I understood this correctly, the problem seems to be in the creation of the `row_index` (see the lines affected in the changeset). I therefore changed the way it is calculated, to force it to be monotone increasing.

    
