### PR TITLE
let it install on julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
     - linux
     - osx
 julia:
+    - 0.7
     - 1.0
     - 1.1
     - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-julia = "^1"
+julia = "0.7, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
is there a reason not to?  the 1.0 API is identical to 0.7, so it should work.  and i've got some old 0.7 programs i'd like to use XLSX with.