### PR TITLE
Public API docstrings.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -77,7 +77,7 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[ZipFile]]
-deps = ["BinaryProvider", "Libdl", "Printf", "Test"]
-git-tree-sha1 = "5f6f663890dfb9bad6af75a86a43f67904e5050e"
+deps = ["BinaryProvider", "Libdl", "Printf"]
+git-tree-sha1 = "580ce62b6c14244916cc28ad54f8a2e2886f843d"
 uuid = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
-version = "0.8.1"
+version = "0.8.3"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,26 @@
 
 # API Reference
 
-```@autodocs
-Modules = [XLSX]
+```@docs
+XLSX.XLSXFile
+XLSX.readxlsx
+XLSX.openxlsx
+XLSX.writexlsx
+XLSX.sheetnames
+XLSX.sheetcount
+XLSX.Worksheet
+XLSX.readdata
+XLSX.getdata
+XLSX.getcell
+XLSX.getcellrange
+XLSX.row_number
+XLSX.column_number
+XLSX.eachrow
+XLSX.readtable
+XLSX.gettable
+XLSX.eachtablerow
+XLSX.writetable
+XLSX.writetable!
+XLSX.rename!
+XLSX.addsheet!
 ```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -75,7 +75,6 @@ julia> xf["mysheet!A:B"] # Column ranges are also supported
  1           "first"
  2           "second"
  3           "third"
-
 ```
 
 To inspect the internal representation of each cell, use the `getcell` or `getcellrange` methods.

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -181,13 +181,10 @@ function _celldata_datetime(v::AbstractString, _is_date_1904::Bool) :: Union{Dat
     end
 end
 
-"""
-Converts Excel number to Time.
-`x` must be between 0 and 1.
-
-To represent Time, Excel uses the decimal part
-of a floating point number. `1` equals one day.
-"""
+# Converts Excel number to Time.
+# `x` must be between 0 and 1.
+# To represent Time, Excel uses the decimal part
+# of a floating point number. `1` equals one day.
 function excel_value_to_time(x::Float64) :: Dates.Time
     @assert x >= 0 && x <= 1
     return Dates.Time(Dates.Nanosecond(round(Int, x * 86400) * 1E9 ))
@@ -195,11 +192,7 @@ end
 
 time_to_excel_value(x::Dates.Time) :: Float64 = Dates.value(x) / ( 86400 * 1E9 )
 
-"""
-Converts Excel number to Date.
-
-See also: [`XLSX.isdate1904`](@ref) function.
-"""
+# Converts Excel number to Date. See also XLSX.isdate1904.
 function excel_value_to_date(x::Int, _is_date_1904::Bool) :: Dates.Date
     if _is_date_1904
         return Dates.Date(Dates.rata2datetime(x + 695056))
@@ -216,14 +209,10 @@ function date_to_excel_value(date::Dates.Date, _is_date_1904::Bool) :: Int
     end
 end
 
-"""
-Converts Excel number to DateTime.
-
-The decimal part represents the Time (see `_time` function).
-The integer part represents the Date.
-
-See also: [`XLSX.isdate1904`](@ref).
-"""
+# Converts Excel number to DateTime.
+# The decimal part represents the Time (see `_time` function).
+# The integer part represents the Date.
+# See also XLSX.isdate1904.
 function excel_value_to_datetime(x::Float64, _is_date_1904::Bool) :: Dates.DateTime
     @assert x >= 0
 

--- a/src/cellref.jl
+++ b/src/cellref.jl
@@ -11,18 +11,7 @@ end
 @inline column_number(p::CellPosition) = p.column
 @inline CellRef(p::CellPosition) = CellRef(row_number(p), column_number(p))
 
-"""
-    decode_column_number(column_name::AbstractString) :: Int
-
-Converts column name to a column number.
-
-```julia
-julia> XLSX.decode_column_number("D")
-4
-```
-
-See also: [`XLSX.encode_column_number`](@ref).
-"""
+# Converts column name to a column number. See also XLSX.encode_column_number.
 function decode_column_number(column_name::AbstractString) :: Int
     local result::Int = 0
 
@@ -39,20 +28,7 @@ function decode_column_number(column_name::AbstractString) :: Int
     return result
 end
 
-"""
-    encode_column_number(column_number::Int) :: String
-
-Converts column number to a column name.
-
-# Example
-
-```julia
-julia> XLSX.encode_column_number(4)
-"D"
-```
-
-See also: [`XLSX.decode_column_number`](@ref).
-"""
+# Converts column number to a column name. See also XLSX.decode_column_number.
 function encode_column_number(column_number::Int) :: String
     @assert column_number > 0 && column_number <= 16384 "Column number should be in the range from 1 to 16384."
 
@@ -103,18 +79,7 @@ end
 const RGX_CELLNAME_LEFT = r"^[A-Z]+"
 const RGX_CELLNAME_RIGHT = r"[0-9]+$"
 
-"""
-    split_cellname(n::AbstractString) -> column_name, row_number
-
-Splits a string representing a cell name to its column name and row number.
-
-# Example
-
-```julia
-julia> XLSX.split_cellname("AB:12")
-("AB:", 12)
-```
-"""
+# Splits a string representing a cell name to its column name and row number.
 @inline function split_cellname(n::AbstractString)
     @assert isascii(n) "$n is not a valid cell name."
     for (i, c) in enumerate(n)
@@ -129,13 +94,7 @@ julia> XLSX.split_cellname("AB:12")
     error("Couldn't split (column_name, row) for cellname $n.")
 end
 
-"""
-    is_valid_cellname(n::AbstractString) :: Bool
-
-Checks wether `n` is a valid name for a cell.
-
-Cell names are bounded by `A1 : XFD1048576`.
-"""
+# Checks wether `n` is a valid name for a cell.
 function is_valid_cellname(n::AbstractString) :: Bool
 
     if !occursin(RGX_CELLNAME, n)
@@ -158,7 +117,7 @@ end
 const RGX_CELLRANGE_START = r"^[A-Z]+[0-9]+"
 const RGX_CELLRANGE_STOP = r"[A-Z]+[0-9]+$"
 
-"""
+#=
     split_cellrange(n::AbstractString) -> start_name, stop_name
 
 Splits a string representing a cell range into its cell names.
@@ -169,7 +128,7 @@ Splits a string representing a cell range into its cell names.
 julia> XLSX.split_cellrange("AB12:CD24")
 ("AB12", "CD24")
 ```
-"""
+=#
 @inline function split_cellrange(n::AbstractString)
     s = split(n, ":")
     @assert length(s) == 2 "$n is not a valid cell range."
@@ -216,11 +175,7 @@ macro range_str(cellrange)
     CellRange(cellrange)
 end
 
-"""
-    Base.in(ref::CellRef, rng::CellRange) :: Bool
-
-Checks wether `ref` is a cell reference inside a range given by `rng`.
-"""
+# Checks wether `ref` is a cell reference inside a range given by `rng`.
 function Base.in(ref::CellRef, rng::CellRange) :: Bool
     top = row_number(rng.start)
     bottom = row_number(rng.stop)
@@ -239,11 +194,7 @@ function Base.in(ref::CellRef, rng::CellRange) :: Bool
     return false
 end
 
-"""
-    Base.issubset(subrng::CellRange, rng::CellRange)
-
-Checks wether `subrng` is a cell range contained in `rng`.
-"""
+# Checks wether `subrng` is a cell range contained in `rng`.
 Base.issubset(subrng::CellRange, rng::CellRange) :: Bool = in(subrng.start, rng) && in(subrng.stop, rng)
 
 function Base.size(rng::CellRange)
@@ -271,7 +222,7 @@ column_number(c::CellRef) :: Int = c.column_number
 
 column_name(c::CellRef) :: String = encode_column_number(column_number(c))
 
-"""
+#=
 Returns (row, column) representing a `ref` position relative to `rng`.
 
 For example, for a range "B2:D4", we have:
@@ -283,8 +234,7 @@ For example, for a range "B2:D4", we have:
 * "C4" relative position is (3, 2)
 
 * "D4" relative position is (3, 3)
-
-"""
+=#
 function relative_cell_position(ref::CellRef, rng::CellRange)
     @assert ref ∈ rng "$ref is outside range $rng."
 
@@ -318,9 +268,7 @@ const RGX_COLUMN_RANGE_START = r"^[A-Z]+"
 const RGX_COLUMN_RANGE_STOP = r"[A-Z]+$"
 const RGX_SINGLE_COLUMN = r"^[A-Z]+$"
 
-"""
-Returns tuple (column_name_start, column_name_stop).
-"""
+# Returns tuple (column_name_start, column_name_stop).
 @inline function split_column_range(n::AbstractString)
     if length(n) == 1
         return n, n

--- a/src/read.jl
+++ b/src/read.jl
@@ -32,7 +32,7 @@ Main function for reading an Excel file.
 This function will read the whole Excel file into memory
 and return a closed XLSXFile.
 
-Consider using `openxlsx` for lazy loading of Excel file contents.
+Consider using [`XLSX.openxlsx`](@ref) for lazy loading of Excel file contents.
 """
 @inline readxlsx(filepath::AbstractString) :: XLSXFile = open_or_read_xlsx(filepath, true, true, false)
 
@@ -273,10 +273,8 @@ function check_minimum_requirements(xf::XLSXFile)
     nothing
 end
 
-"""
-Parses package level relationships defined in `_rels/.rels`.
-Prases workbook level relationships defined in `xl/_rels/workbook.xml.rels`.
-"""
+# Parses package level relationships defined in `_rels/.rels`.
+# Parses workbook level relationships defined in `xl/_rels/workbook.xml.rels`.
 function parse_relationships!(xf::XLSXFile)
 
     # package level relationships
@@ -297,11 +295,7 @@ function parse_relationships!(xf::XLSXFile)
     nothing
 end
 
-"""
-  parse_workbook!(xf::XLSXFile)
-
-Updates xf.workbook from xf.data[\"xl/workbook.xml\"]
-"""
+# Updates xf.workbook from xf.data[\"xl/workbook.xml\"]
 function parse_workbook!(xf::XLSXFile)
     xroot = xmlroot(xf, "xl/workbook.xml")
     @assert EzXML.nodename(xroot) == "workbook" "Malformed xl/workbook.xml. Root node name should be 'workbook'. Got '$(EzXML.nodename(xroot))'."
@@ -420,14 +414,10 @@ end
 
 # Lazy loading of XML files
 
-"""
-Lists internal files from the XLSX package.
-"""
+# Lists internal files from the XLSX package.
 @inline filenames(xl::XLSXFile) = keys(xl.files)
 
-"""
-Returns true if the file data was read into xl.data.
-"""
+# Returns true if the file data was read into xl.data.
 @inline internal_xml_file_isread(xl::XLSXFile, filename::String) :: Bool = xl.files[filename]
 @inline internal_xml_file_exists(xl::XLSXFile, filename::String) :: Bool = haskey(xl.files, filename)
 
@@ -475,20 +465,12 @@ end
 
 Base.isopen(xl::XLSXFile) = xl.io_is_open
 
-"""
-    xmldocument(xl::XLSXFile, filename::String) :: EzXML.Document
-
-Utility method to find the XMLDocument associated with a given package filename.
-Returns xl.data[filename] if it exists. Throws an error if it doesn't.
-"""
+# Utility method to find the XMLDocument associated with a given package filename.
+# Returns xl.data[filename] if it exists. Throws an error if it doesn't.
 @inline xmldocument(xl::XLSXFile, filename::String) :: EzXML.Document = internal_xml_file_read(xl, filename)
 
-"""
-    xmlroot(xl::XLSXFile, filename::String) :: EzXML.Node
-
-Utility method to return the root element of a given XMLDocument from the package.
-Returns EzXML.root(xl.data[filename]) if it exists.
-"""
+# Utility method to return the root element of a given XMLDocument from the package.
+# Returns EzXML.root(xl.data[filename]) if it exists.
 @inline xmlroot(xl::XLSXFile, filename::String) :: EzXML.Node = EzXML.root(xmldocument(xl, filename))
 
 #
@@ -500,6 +482,8 @@ Returns EzXML.root(xl.data[filename]) if it exists.
     readdata(filepath, sheetref)
 
 Returns a scalar or matrix with values from a spreadsheet.
+
+See also [`XLSX.getdata`](@ref).
 
 # Examples
 

--- a/src/relationship.jl
+++ b/src/relationship.jl
@@ -61,9 +61,7 @@ function get_workbook_relationship_root(xf::XLSXFile) :: EzXML.Node
     return xroot
 end
 
-"""
-Adds new relationship. Returns new generated rId.
-"""
+# Adds new relationship. Returns new generated rId.
 function add_relationship!(wb::Workbook, target::String, _type::String) :: String
     xf = get_xlsxfile(wb)
     @assert is_writable(xf) "XLSXFile instance is not writable."

--- a/src/sst.jl
+++ b/src/sst.jl
@@ -6,11 +6,9 @@ SharedStringTable() = SharedStringTable(Vector{String}(), Vector{String}(), fals
 @inline Base.length(sst::SharedStringTable) = length(sst.formatted_strings)
 @inline Base.isempty(sst::SharedStringTable) = isempty(sst.formatted_strings)
 
-"""
-Checks if string is inside shared string table.
-Returns `nothing` if it's not in the shared string table.
-Returns the index of the string in the shared string table. The index is 0-based.
-"""
+# Checks if string is inside shared string table.
+# Returns `nothing` if it's not in the shared string table.
+# Returns the index of the string in the shared string table. The index is 0-based.
 function get_shared_string_index(sst::SharedStringTable, str_formatted::AbstractString) :: Union{Nothing, Int}
     @assert sst.is_loaded "Can't query shared string table because it's not loaded into memory."
 
@@ -37,11 +35,7 @@ function add_shared_string!(sst::SharedStringTable, str_unformatted::AbstractStr
     end
 end
 
-"""
-    add_shared_string!(sheet, str_unformatted, [str_formatted]) :: Int
-
-Add string to shared string table. Returns the 0-based index of the shared string in the shared string table.
-"""
+# Adds a string to shared string table. Returns the 0-based index of the shared string in the shared string table.
 function add_shared_string!(wb::Workbook, str_unformatted::AbstractString, str_formatted::AbstractString) :: Int
     @assert is_writable(get_xlsxfile(wb)) "XLSXFile instance is not writable."
     @assert !(isempty(str_unformatted) || isempty(str_formatted)) "Can't add empty string to Shared String Table."
@@ -100,23 +94,15 @@ function sst_load!(workbook::Workbook)
     end
 end
 
-"""
-    has_sst(workbook::Workbook)
-
-Checks wether this workbook has a Shared String Table.
-"""
+# Checks wether this workbook has a Shared String Table.
 function has_sst(workbook::Workbook) :: Bool
     relationship_type = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"
     return has_relationship_by_type(workbook, relationship_type)
 end
 
-"""
-    unformatted_text(el::EzXML.Node) :: String
-
-Helper function to gather unformatted text from Excel data files.
-It looks at all childs of `el` for tag name `t` and returns
-a join of all the strings found.
-"""
+# Helper function to gather unformatted text from Excel data files.
+# It looks at all childs of `el` for tag name `t` and returns
+# a join of all the strings found.
 function unformatted_text(el::EzXML.Node) :: String
 
     function gather_strings!(v::Vector{String}, e::EzXML.Node)
@@ -136,23 +122,15 @@ function unformatted_text(el::EzXML.Node) :: String
     return join(v_string)
 end
 
-"""
-    sst_unformatted_string(wb, index) :: String
-
-Looks for a string inside the Shared Strings Table (sst).
-`index` starts at 0.
-"""
+# Looks for a string inside the Shared Strings Table (sst).
+# `index` starts at 0.
 @inline function sst_unformatted_string(wb::Workbook, index::Int)
     sst_load!(wb)
     return get_sst(wb).unformatted_strings[index+1]
 end
 
-"""
-    sst_formatted_string(wb, index) :: String
-
-Looks for a formatted string inside the Shared Strings Table (sst).
-`index` starts at 0.
-"""
+# Looks for a formatted string inside the Shared Strings Table (sst).
+# `index` starts at 0.
 @inline function sst_formatted_string(wb::Workbook, index::Int)
     sst_load!(wb)
     return get_sst(wb).formatted_strings[index+1]

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -41,9 +41,7 @@ The iterator element is a SheetRow.
 
 Base.show(io::IO, state::SheetRowStreamIteratorState) = print(io, "SheetRowStreamIteratorState( is open = $(state.is_open) , row = $(state.row) )")
 
-"""
-Open a file for streaming.
-"""
+# Opens a file for streaming.
 @inline function open_internal_file_stream(xf::XLSXFile, filename::String) :: Tuple{ZipFile.Reader, EzXML.StreamReader}
     @assert internal_xml_file_exists(xf, filename) "Couldn't find $filename in $(xf.filepath)."
     @assert isfile(xf.filepath) "Can't open internal file $filename for streaming because the XLSX file $(xf.filepath) was not found."
@@ -70,14 +68,9 @@ end
 end
 
 
-"""
-    SheetRowStreamIterator(ws::Worksheet)
-
-Creates a reader for row elements in the Worksheet's XML.
-Will return a stream reader positioned in the first row element if it exists.
-
-If there's no row element inside sheetData XML tag, it will close all streams and return `nothing`.
-"""
+# Creates a reader for row elements in the Worksheet's XML.
+# Will return a stream reader positioned in the first row element if it exists.
+# If there's no row element inside sheetData XML tag, it will close all streams and return `nothing`.
 function Base.iterate(itr::SheetRowStreamIterator, state::Union{Nothing, SheetRowStreamIteratorState}=nothing)
 
     if state == nothing # first iteration. Will open a stream and create the first state instance
@@ -173,18 +166,14 @@ function Base.iterate(itr::SheetRowStreamIterator, state::Union{Nothing, SheetRo
     return sheet_row, state
 end
 
-"""
-Detects a closing sheetData element
-"""
+#Detects a closing sheetData element
 @inline is_end_of_sheet_data(r::EzXML.StreamReader) = (EzXML.nodedepth(r) <= 1) || (EzXML.nodetype(r) == EzXML.READER_END_ELEMENT && EzXML.nodename(r) == "sheetData")
 
 #
 # WorksheetCache
 #
 
-"""
-Indicates wether worksheet cache will be fed while reading worksheet cells.
-"""
+# Indicates wether worksheet cache will be fed while reading worksheet cells.
 @inline is_cache_enabled(ws::Worksheet) = is_cache_enabled(get_xlsxfile(ws))
 @inline is_cache_enabled(wb::Workbook) = is_cache_enabled(get_xlsxfile(wb))
 @inline is_cache_enabled(xl::XLSXFile) = xl.use_cache_for_sheet_data
@@ -263,6 +252,16 @@ end
 
 row_number(sr::SheetRow) = sr.row
 
+"""
+    getcell(xlsxfile, cell_reference_name) :: AbstractCell
+    getcell(worksheet, cell_reference_name) :: AbstractCell
+    getcell(sheetrow, column_name) :: AbstractCell
+    getcell(sheetrow, column_number) :: AbstractCell
+
+Returns the internal representation of a worksheet cell.
+
+Returns `XLSX.EmptyCell` if the cell has no data.
+"""
 function getcell(r::SheetRow, column_index::Int) :: AbstractCell
     if haskey(r.rowcells, column_index)
         return r.rowcells[column_index]

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -31,9 +31,7 @@ const DEFAULT_DATE_numFmtId = 14 # dd-mm-yyyy
 const DEFAULT_TIME_numFmtId = 20 # h:mm
 const DEFAULT_DATETIME_numFmtId = 22 # dd-mm-yyyy h:mm
 
-"""
-Returns the default `CellDataFormat` for a type
-"""
+# Returns the default `CellDataFormat` for a type
 default_cell_format(::Worksheet, ::CellValueType) = EmptyCellDataFormat()
 default_cell_format(ws::Worksheet, ::Dates.Date) = get_num_style_index(ws, DEFAULT_DATE_numFmtId)
 default_cell_format(ws::Worksheet, ::Dates.Time) = get_num_style_index(ws, DEFAULT_TIME_numFmtId)
@@ -74,26 +72,22 @@ function styles_xmlroot(workbook::Workbook)
     return workbook.styles_xroot
 end
 
-"""
-Returns the xf XML node element for style `index`.
-`index` is 0-based.
-"""
+# Returns the xf XML node element for style `index`.
+# `index` is 0-based.
 function styles_cell_xf(wb::Workbook, index::Int) :: EzXML.Node
     xroot = styles_xmlroot(wb)
     xf_elements = findall("/xpath:styleSheet/xpath:cellXfs/xpath:xf", xroot, SPREADSHEET_NAMESPACE_XPATH_ARG)
     return xf_elements[index+1]
 end
 
-"Queries numFmtId from cellXfs -> xf nodes."
+# Queries numFmtId from cellXfs -> xf nodes."
 function styles_cell_xf_numFmtId(wb::Workbook, index::Int) :: Int
     el = styles_cell_xf(wb, index)
     return parse(Int, el["numFmtId"])
 end
 
-"""
-Defines a custom number format to render numbers, dates or text.
-Returns the index to be used as the `numFmtId` in a cellXf definition.
-"""
+# Defines a custom number format to render numbers, dates or text.
+# Returns the index to be used as the `numFmtId` in a cellXf definition.
 function styles_add_numFmt(wb::Workbook, format_code::AbstractString) :: Integer
     xroot = styles_xmlroot(wb)
 
@@ -117,9 +111,7 @@ end
 
 const FontAttribute = Union{AbstractString, Pair{String, Pair{String, String}}}
 
-"""
-Defines a custom font. Returns the index to be used as the `fontId` in a cellXf definition.
-"""
+# Defines a custom font. Returns the index to be used as the `fontId` in a cellXf definition.
 function styles_add_font(wb::Workbook, attributes::Vector{FontAttribute})
     xroot = styles_xmlroot(wb)
     fonts_element = findfirst("/xpath:styleSheet/xpath:fonts", xroot, SPREADSHEET_NAMESPACE_XPATH_ARG)
@@ -140,9 +132,7 @@ function styles_add_font(wb::Workbook, attributes::Vector{FontAttribute})
 end
 
 
-"""
-Queries numFmt formatCode field by numFmtId.
-"""
+# Queries numFmt formatCode field by numFmtId.
 function styles_numFmt_formatCode(wb::Workbook, numFmtId::AbstractString) :: String
     xroot = styles_xmlroot(wb)
     elements_found = findall("/xpath:styleSheet/xpath:numFmts/xpath:numFmt[@numFmtId='$(numFmtId)']", xroot, SPREADSHEET_NAMESPACE_XPATH_ARG)
@@ -234,7 +224,7 @@ end
 styles_is_float(wb::Workbook, fmt::CellDataFormat) = styles_is_float(wb, Int(fmt.id))
 styles_is_float(ws::Worksheet, index) = styles_is_float(get_workbook(ws), index)
 
-"""
+#=
 Cell Xf element follows the XML format below.
 This function queries the 0-based index of the first xf element that has the provided numFmtId.
 Returns -1 if not found.
@@ -247,7 +237,7 @@ Returns -1 if not found.
             <xf applyNumberFormat="1" borderId="0" fillId="0" fontId="0" numFmtId="20" xfId="0"/>
             <xf applyNumberFormat="1" borderId="0" fillId="0" fontId="0" numFmtId="22" xfId="0"/>
 ```
-"""
+=#
 function styles_get_cellXf_with_numFmtId(wb::Workbook, numFmtId::Int) :: AbstractCellDataFormat
     xroot = styles_xmlroot(wb)
     elements_found = findall("/xpath:styleSheet/xpath:cellXfs/xpath:xf", xroot, SPREADSHEET_NAMESPACE_XPATH_ARG)

--- a/src/table.jl
+++ b/src/table.jl
@@ -3,11 +3,7 @@
 # Table
 #
 
-"""
-   column_bounds(sr::SheetRow)
-
-Returns a tuple with the first and last index of the columns for a `SheetRow`.
-"""
+# Returns a tuple with the first and last index of the columns for a `SheetRow`.
 function column_bounds(sr::SheetRow)
 
     @assert !isempty(sr) "Can't get column bounds from an empty row."
@@ -198,20 +194,14 @@ end
 
 @inline get_worksheet(tri::TableRowIterator) = get_worksheet(tri.itr)
 
-"""
-Returns real sheet column numbers (based on cellref)
-"""
+# Returns real sheet column numbers (based on cellref)
 @inline sheet_column_numbers(i::Index) = values(i.column_map)
 
-"""
-Returns an iterator for table column numbers.
-"""
+# Returns an iterator for table column numbers.
 @inline table_column_numbers(i::Index) = eachindex(i.column_labels)
 @inline table_column_numbers(r::TableRow) = table_column_numbers(r.index)
 
-"""
-Maps table column index (1-based) -> sheet column index (cellref based)
-"""
+# Maps table column index (1-based) -> sheet column index (cellref based)
 @inline table_column_to_sheet_column_number(index::Index, table_column_number::Int) = index.column_map[table_column_number]
 @inline table_columns_count(i::Index) = length(i.column_labels)
 @inline table_columns_count(itr::TableRowIterator) = table_columns_count(itr.index)

--- a/src/workbook.jl
+++ b/src/workbook.jl
@@ -3,17 +3,18 @@ EmptyWorkbook() = Workbook(EmptyMSOfficePackage(), Vector{Worksheet}(), false,
     Vector{Relationship}(), SharedStringTable(), Dict{Int, Bool}(), Dict{Int, Bool}(),
     Dict{String, DefinedNameValueTypes}(), Dict{Tuple{Int, String}, DefinedNameValueTypes}(), nothing)
 
-"""
-    is_writable(xl::XLSXFile)
-
+#=
 Indicates wether this XLSX file can be edited.
 This controls if assignment to worksheet cells is allowed.
 Writable XLSXFile instances are opened with `XLSX.open_xlsx_template` method.
-"""
+=#
 is_writable(xl::XLSXFile) = xl.is_writable
 
 """
-Lists Worksheet names for this Workbook.
+    sheetnames(xl::XLSXFile)
+    sheetnames(wb::Workbook)
+
+Returns a vector with Worksheet names for this Workbook.
 """
 sheetnames(wb::Workbook) = [ s.name for s in wb.sheets ]
 @inline sheetnames(xl::XLSXFile) = sheetnames(xl.workbook)
@@ -30,16 +31,14 @@ end
 @inline hassheet(xl::XLSXFile, sheetname::AbstractString) = hassheet(xl.workbook, sheetname)
 
 """
+    sheetcount(xlsfile) :: Int
+
 Counts the number of sheets in the Workbook.
 """
 @inline sheetcount(wb::Workbook) = length(wb.sheets)
 @inline sheetcount(xl::XLSXFile) = sheetcount(xl.workbook)
 
-"""
-    isdate1904(wb) :: Bool
-
-Returns true if workbook follows date1904 convention.
-"""
+# Returns true if workbook follows date1904 convention.
 @inline isdate1904(wb::Workbook) :: Bool = wb.date1904
 @inline isdate1904(xf::XLSXFile) :: Bool = isdate1904(get_workbook(xf))
 

--- a/src/worksheet.jl
+++ b/src/worksheet.jl
@@ -42,12 +42,8 @@ end
 
 @inline isdate1904(ws::Worksheet) = isdate1904(get_workbook(ws))
 
-"""
-    get_dimension(ws::Worksheet) :: Union{Nothing, CellRange}
-
-Retuns the dimension of this worksheet as a CellRange.
-Returns `nothing` if the dimension is unknown.
-"""
+# Retuns the dimension of this worksheet as a CellRange.
+# Returns `nothing` if the dimension is unknown.
 @inline get_dimension(ws::Worksheet) :: Union{Nothing, CellRange} = ws.dimension
 
 function set_dimension!(ws::Worksheet, rng::CellRange)

--- a/src/write.jl
+++ b/src/write.jl
@@ -1,22 +1,22 @@
 
-"""
+#=
     open_xlsx_template(filepath::AbstractString) :: XLSXFile
 
 Open an Excel file as template for editing and saving to another file with `XLSX.writexlsx`.
 
 The returned `XLSXFile` instance is in closed state.
-"""
+=#
 @inline open_xlsx_template(filepath::AbstractString) :: XLSXFile = open_or_read_xlsx(filepath, true, true, true)
 
 const EMPTY_EXCEL_TEMPLATE = joinpath(@__DIR__, "..", "data", "blank.xlsx")
 
-"""
+#=
     open_empty_template(sheetname::AbstractString="") :: XLSXFile
 
 Returns an empty, writable `XLSXFile` with 1 worksheet.
 
 `sheetname` is the name of the worksheet, defaults to `Sheet1`.
-"""
+=#
 function open_empty_template(sheetname::AbstractString="") :: XLSXFile
     @assert isfile(EMPTY_EXCEL_TEMPLATE) "Couldn't find template file $EMPTY_EXCEL_TEMPLATE."
     xf = open_xlsx_template(EMPTY_EXCEL_TEMPLATE)
@@ -273,9 +273,7 @@ function xlsx_escape(str::AbstractString)
     return String(take!(buffer))
 end
 
-"""
-Returns the datatype and value for `val` to be inserted into `ws`.
-"""
+# Returns the datatype and value for `val` to be inserted into `ws`.
 function xlsx_encode(ws::Worksheet, val::AbstractString)
     if isempty(val)
         return ("", "")
@@ -422,6 +420,11 @@ function writetable!(sheet::Worksheet, data, columnnames; anchor_cell::CellRef=C
     end
 end
 
+"""
+    rename!(ws::Worksheet, name::AbstractString)
+
+Renames a `Worksheet`.
+"""
 function rename!(ws::Worksheet, name::AbstractString)
     xf = get_xlsxfile(ws)
     @assert is_writable(xf) "XLSXFile instance is not writable."
@@ -457,7 +460,6 @@ addsheet!(xl::XLSXFile, name::AbstractString="") :: Worksheet = addsheet!(get_wo
 
 Create a new worksheet with named `name`.
 If `name` is not provided, a unique name is created.
-
 """
 function addsheet!(wb::Workbook, name::AbstractString="") :: Worksheet
 


### PR DESCRIPTION
All public methods now have docstrings documented at docs API page.

Docstrings for private methods were replaced by comments.

This implements #85.