### PR TITLE
Return missing for empty cells of type "s"

### DIFF
--- a/src/cell.jl
+++ b/src/cell.jl
@@ -104,6 +104,11 @@ function getdata(ws::Worksheet, cell::Cell) :: CellValueType
     end
 
     if cell.datatype == "s"
+
+        if isempty(cell.value)
+            return missing
+        end
+
         # use sst
         str = sst_unformatted_string(ws, cell.value)
 


### PR DESCRIPTION
For most other cell data types, we're returning `missing` if the cell value is empty. The check for emptiness comes after the call to `sst_unformatted_string`, but `sst_unformatted_string` calls `parse(Int, _)` on `cell.value`, which errors if `cell.value` is empty. Thus here I've inserted a check in keeping with other branches for `isempty(cell.value)`.

I don't really know anything about the internals of this package (or about the XLSX format) and I'm not sure how to unit test this, but this fixes an issue I encountered.