### PR TITLE
Fix Excel numFmts bug

### DIFF
--- a/src/styles.jl
+++ b/src/styles.jl
@@ -94,7 +94,12 @@ function styles_add_numFmt(wb::Workbook, format_code::AbstractString) :: Integer
     numfmts = findall("/xpath:styleSheet/xpath:numFmts", xroot, SPREADSHEET_NAMESPACE_XPATH_ARG)
     if isempty(numfmts)
         stylesheet = findfirst("/xpath:styleSheet", xroot, SPREADSHEET_NAMESPACE_XPATH_ARG)
+
+        # We need to add the numFmts node directly after the styleSheet node
+        child = EzXML.firstelement(stylesheet)
         numfmts = EzXML.addelement!(stylesheet, "numFmts")
+        EzXML.unlink!(numfmts)
+        EzXML.linkprev!(child, numfmts)
     else
         numfmts = numfmts[1]
     end


### PR DESCRIPTION
Fixes #114 

Looks like Excel is a stickler for where the `numFmts` Element should exist in the `xl/styles.xml`. It seem to want it to be the first element under the `styleSheet` element.

This MR fixes that issue by linking the `numFmts` element before the first child element in `styleSheet`.

I wasn't able to figure out how to do this without the `addelement!` -> `unlink!` -> `linkprev!`, if I purely do a `linkprev!`, then line 94 stops being able to find the `numFmts` element block for some reason, and will just keep adding `numFmts` element blocks. 