### PR TITLE
Perf - don't use do block for readtable

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -579,15 +579,15 @@ julia> df = DataFrame(XLSX.readtable("myfile.xlsx", "mysheet")...)
 See also: [`XLSX.gettable`](@ref).
 """
 function readtable(filepath::AbstractString, sheet::Union{AbstractString, Int}; first_row::Union{Nothing, Int} = nothing, column_labels::Vector{Symbol}=Vector{Symbol}(), header::Bool=true, infer_eltypes::Bool=false, stop_in_empty_row::Bool=true, stop_in_row_function::Union{Nothing, Function}=nothing, enable_cache::Bool=false)
-    c = openxlsx(filepath, enable_cache=enable_cache) do xf
-        gettable(getsheet(xf, sheet); first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
-    end
+    xf = openxlsx(filepath, enable_cache=enable_cache) 
+    c = gettable(getsheet(xf, sheet); first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
+    close(xf)
     return c
 end
 
 function readtable(filepath::AbstractString, sheet::Union{AbstractString, Int}, columns::Union{ColumnRange, AbstractString}; first_row::Union{Nothing, Int} = nothing, column_labels::Vector{Symbol}=Vector{Symbol}(), header::Bool=true, infer_eltypes::Bool=false, stop_in_empty_row::Bool=true, stop_in_row_function::Union{Nothing, Function}=nothing, enable_cache::Bool=false)
-    c = openxlsx(filepath, enable_cache=enable_cache) do xf
-        gettable(getsheet(xf, sheet), columns; first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
-    end
+    xf = openxlsx(filepath, enable_cache=enable_cache)
+    c = gettable(getsheet(xf, sheet), columns; first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
+    close(xf)
     return c
 end

--- a/src/read.jl
+++ b/src/read.jl
@@ -580,14 +580,18 @@ See also: [`XLSX.gettable`](@ref).
 """
 function readtable(filepath::AbstractString, sheet::Union{AbstractString, Int}; first_row::Union{Nothing, Int} = nothing, column_labels::Vector{Symbol}=Vector{Symbol}(), header::Bool=true, infer_eltypes::Bool=false, stop_in_empty_row::Bool=true, stop_in_row_function::Union{Nothing, Function}=nothing, enable_cache::Bool=false)
     xf = openxlsx(filepath, enable_cache=enable_cache) 
-    c = gettable(getsheet(xf, sheet); first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
-    close(xf)
-    return c
+    try
+        gettable(getsheet(xf, sheet); first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
+    finally
+        close(xf)
+    end
 end
 
 function readtable(filepath::AbstractString, sheet::Union{AbstractString, Int}, columns::Union{ColumnRange, AbstractString}; first_row::Union{Nothing, Int} = nothing, column_labels::Vector{Symbol}=Vector{Symbol}(), header::Bool=true, infer_eltypes::Bool=false, stop_in_empty_row::Bool=true, stop_in_row_function::Union{Nothing, Function}=nothing, enable_cache::Bool=false)
     xf = openxlsx(filepath, enable_cache=enable_cache)
-    c = gettable(getsheet(xf, sheet), columns; first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
-    close(xf)
-    return c
+    try
+        gettable(getsheet(xf, sheet), columns; first_row=first_row, column_labels=column_labels, header=header, infer_eltypes=infer_eltypes, stop_in_empty_row=stop_in_empty_row, stop_in_row_function=stop_in_row_function)
+    finally
+        close(xf)
+    end
 end


### PR DESCRIPTION
This ends up being surprisingly expensive!  

My timings include pending PRs to EzXML & ZipFile - for reference pandas parses this file in ~80 ms, and R's read_xl, which has a better parser, does it in ~45ms, so post this + those changes pretty happy with where overall performance is.

```
# master
julia> @btime XLSX.readtable(f, "Sheet1")
  112.970 ms (280165 allocations: 11.58 MiB)

# pr
julia> @btime XLSX.readtable(f, "Sheet1")
  47.748 ms (280068 allocations: 11.58 MiB)
```