### PR TITLE
Fix writetable() for typed tables

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -658,7 +658,7 @@ function writetable(filename::AbstractString; overwrite::Bool=false, kw...)
     nothing
 end
 
-function writetable(filename::AbstractString, tables::Vector{Tuple{String, Vector{Any}, Vector{T}}}; overwrite::Bool=false) where {T<:Union{String, Symbol}}
+function writetable(filename::AbstractString, tables::Vector{Tuple{String, S, Vector{T}}}; overwrite::Bool=false) where {S<:Vector{U} where U<:Any, T<:Union{String, Symbol}}
 
     if !overwrite
         @assert !isfile(filename) "$filename already exists."

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1205,6 +1205,26 @@ end
         @test labels[1] == :COLUMN_A
         @test labels[2] == :COLUMN_B
         check_test_data(data, report_2_data)
+
+        report_1_column_names = ["HEADER_A", "HEADER_B"]
+        report_1_data = [["1", "2", "3"], ["A", "B", ""]]
+
+        report_2_column_names = ["COLUMN_A", "COLUMN_B"]
+        report_2_data = Vector{Any}(undef, 2)
+        report_2_data[1] = [Date(2017,2,1), Date(2018,2,1)]
+        report_2_data[2] = [10.2, 10.3]
+
+        XLSX.writetable("output_tables.xlsx", [ ("REPORT_A", report_1_data, report_1_column_names), ("REPORT_B", report_2_data, report_2_column_names) ], overwrite=true)
+
+        data, labels = XLSX.readtable("output_tables.xlsx", "REPORT_A")
+        @test labels[1] == :HEADER_A
+        @test labels[2] == :HEADER_B
+        check_test_data(data, report_1_data)
+
+        data, labels = XLSX.readtable("output_tables.xlsx", "REPORT_B")
+        @test labels[1] == :COLUMN_A
+        @test labels[2] == :COLUMN_B
+        check_test_data(data, report_2_data)
     end
 
     # delete files created by this testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -654,11 +654,11 @@ end
 end
 
 # Checks wether `data` equals `test_data`
-function check_test_data(data::Vector{Any}, test_data::Vector{Any})
+function check_test_data(data::Vector{S}, test_data::Vector{T}) where {S<:Any, T<:Any}
 
     @test length(data) == length(test_data)
 
-    function size_of_data(d::Vector{Any})
+    function size_of_data(d::Vector{T}) where {T<:Any}
         isempty(d) && return (0, 0)
         return length(d[1]), length(d)
     end


### PR DESCRIPTION
Currently, writetable() only works for data of type 'Any'. Stronger types throw an error. This can be reproduced using an adapted version of the test:

```
report_1_column_names = ["HEADER_A", "HEADER_B"]
report_1_data = [["1", "2", "3"], ["A", "B", ""]]
report_2_column_names = ["COLUMN_A", "COLUMN_B"]
report_2_data = Vector{Any}(undef, 2)
report_2_data[1] = [Date(2017,2,1), Date(2018,2,1)]
report_2_data[2] = [10.2, 10.3]
XLSX.writetable("output_tables.xlsx", [ ("REPORT_A", report_1_data, report_1_column_names), ("REPORT_B", report_2_data, report_2_column_names) ], overwrite=true)
```

throws

```
ERROR: AssertionError: Can't write table with no columns.
Stacktrace:
 [1] writetable!(::XLSX.Worksheet, ::Array{Any,1}, ::Array{Symbol,1}; anchor_cell::XLSX.CellRef) at /Users/kienscherfp/.julia/packages/XLSX/A7wWu/src/write.jl:401
 [2] writetable(::String, ::Array{Any,1}, ::Array{Symbol,1}; overwrite::Bool, sheetname::String, anchor_cell::XLSX.CellRef) at /Users/kienscherfp/.julia/packages/XLSX/A7wWu/src/write.jl:606
 [3] writetable(::String, ::Array{Tuple{String,Array{T,1} where T,Array{String,1}},1}; kw::Base.Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:overwrite,),Tuple{Bool}}}) at /Users/kienscherfp/.julia/packages/XLSX/A7wWu/src/tables_interface.jl:13
 [4] top-level scope at REPL[10]:1
```

i.e., the wrong method is used. This behavior is fixed with this PR. 