### PR TITLE
fix issue #161

### DIFF
--- a/src/tables_interface.jl
+++ b/src/tables_interface.jl
@@ -1,9 +1,13 @@
 
 # Tables.jl interface
 
-Tables.isrowtable(::Type{<:TableRowIterator}) = true
-Tables.columnnames(tr::TableRow) = Tuple(tr.index.column_labels)
+Tables.istable(::Type{<:TableRowIterator}) = true
+Tables.rowaccess(::Type{<:TableRowIterator}) = true
+Tables.rows(itr::TableRowIterator) = itr
+Tables.schema(itr::TableRowIterator) = Tables.Schema(itr.index.column_labels, fill(Any, length(itr.index.column_labels)))
+Tables.columnnames(tr::TableRow) = tr.index.column_labels
 Tables.getcolumn(tr::TableRow, nm::Symbol) = getdata(tr, nm)
+Tables.getcolumn(tr::TableRow, i::Integer) = getdata(tr, i)
 
 function writetable(filename::AbstractString, x; kw...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1820,7 +1820,8 @@ end
     @test length(ct) == 1
     @test length(ct[1]) == 5
     ct = XLSX.eachtablerow(f["table6"]) |> Tables.columntable
-    @test length(ct) == 0
+    @test length(ct) == 1
+    @test isempty(ct.hey)
     ct = XLSX.eachtablerow(f["table7"]) |> Tables.columntable
     @test length(ct) == 1
     @test length(ct[1]) == 1


### PR DESCRIPTION
This fixes #161 by rewriting the Tables.jl interface, and defining `Tables.schema` for `TableRowIterator`.