### PR TITLE
expand Tables.jl interface for writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/build/*
 **/*.swp
 Manifest.toml
 docs/Manifest.toml
+.vscode

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -300,7 +300,8 @@ You can also use `XLSX.writetable` to write directly to a new file (see next sec
 
 ### Export Tabular Data from a DataFrame
 
-To export tabular data to Excel, use `XLSX.writetable` method.
+To export tabular data to Excel, use `XLSX.writetable` method, which accepts either columns and column names,
+or any `Tables.jl` table.
 
 ```julia
 julia> using Dates
@@ -316,10 +317,13 @@ julia> df = DataFrames.DataFrame(integers=[1, 2, 3, 4], strings=["Hey", "You", "
 │ 3   │ 3        │ Out     │ 30.4   │ 2018-02-22 │ 19:30:00 │ 2018-05-20T19:30:00 │
 │ 4   │ 4        │ There   │ 40.5   │ 2018-02-23 │ 19:40:00 │ 2018-05-20T19:40:00 │
 
+julia> XLSX.writetable("df.xlsx", df)
+
 julia> XLSX.writetable("df.xlsx", collect(DataFrames.eachcol(df)), DataFrames.names(df))
 ```
 
-You can also export multiple tables to Excel, each table in a separate worksheet.
+You can also export multiple tables to Excel, each table in a separate worksheet, by either passing a tuple (columns, names)
+to a keyword argument for each sheet name, or a list `"sheet name" => table` pairs for any Tables.jl compatible source.
 
 ```julia
 julia> import DataFrames, XLSX
@@ -340,6 +344,8 @@ julia> df2 = DataFrames.DataFrame(AA=["aa", "bb"], AB=[10.1, 10.2])
 │ 2   │ bb │ 10.2 │
 
 julia> XLSX.writetable("report.xlsx", REPORT_A=( collect(DataFrames.eachcol(df1)), DataFrames.names(df1) ), REPORT_B=( collect(DataFrames.eachcol(df2)), DataFrames.names(df2) ))
+
+julia> XLSX.writetable("report.xlsx", "REPORT_A" => df1, "REPORT_B" => df1)
 ```
 
 ## Tables.jl interface

--- a/src/tables_interface.jl
+++ b/src/tables_interface.jl
@@ -9,10 +9,35 @@ Tables.columnnames(tr::TableRow) = tr.index.column_labels
 Tables.getcolumn(tr::TableRow, nm::Symbol) = getdata(tr, nm)
 Tables.getcolumn(tr::TableRow, i::Integer) = getdata(tr, i)
 
-function writetable(filename::AbstractString, x; kw...)
-
-	_as_vector(y::AbstractVector) = y
-	_as_vector(y) = collect(y)
-
-    writetable(filename, Any[_as_vector(c) for c in Tables.Columns(x)], collect(Symbol, Tables.columnnames(x)); kw...)
+function table_to_arrays(x)
+    _as_vector(y::AbstractVector) = y
+    _as_vector(y) = collect(y)
+    columns = Any[_as_vector(c) for c in Tables.Columns(x)]
+    names = collect(Symbol, Tables.columnnames(x))
+    return columns, names
 end
+
+"""
+    writetable(filename, table; [overwrite], [sheetname])
+
+Write Tables.jl `table` to the specified filename
+"""
+writetable(filename::AbstractString, x; kw...) = writetable(filename, table_to_arrays(x)...; kw...)
+
+
+"""
+    writetable(filename::AbstractString, tables::Vector{Pair{String, T}}; overwrite::Bool=false)
+    writetable(filename::AbstractString, tables::Pair{String, Any}...; overwrite::Bool=false)
+"""
+function writetable(filename::AbstractString, tables::Vector{<:Pair}; kw...)
+    data = [(name, table_to_arrays(x)...) for (name, x) in tables]
+    return writetable(filename, data; kw...)
+end
+writetable(filename::AbstractString, tables::Pair{<:String, <:Any}...; kw...) = writetable(filename, collect(tables); kw...)
+
+"""
+    writetable!(sheet::Worksheet, table; anchor_cell::CellRef=CellRef("A1")))
+
+Write Tables.jl `table` to the specified sheet
+"""
+writetable!(sheet::Worksheet, x, kw...) = writetable!(sheet, table_to_arrays(x)...; kw...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1842,13 +1842,37 @@ end
     XLSX.writetable("output_table.xlsx", table, overwrite=true, sheetname="report", anchor_cell="B2")
     @test isfile("output_table.xlsx")
 
-    try
-        f = XLSX.readxlsx("output_table.xlsx")
-        s = f["report"]
-        table2 = XLSX.eachtablerow(s) |> Tables.columntable
-        @test isequal(table, table2)
-    finally
-        rm("output_table.xlsx")
+    XLSX.openxlsx("output_table2.xlsx", mode="w") do xf
+        sheet = XLSX.getsheet(xf, 1)
+        XLSX.rename!(sheet, "report")
+        XLSX.writetable!(sheet, table)
+    end
+
+    for file in ["output_table.xlsx", "output_table2.xlsx"]
+        try
+            f = XLSX.readxlsx(file)
+            s = f["report"]
+            table2 = XLSX.eachtablerow(s) |> Tables.columntable
+            @test isequal(table, table2)
+        finally
+            rm(file)
+        end
+    end
+
+    # multiple tables in same file
+    table2 = (a = [1, 2, 3, 4], b=["a", "b", "c", "d"])
+    XLSX.writetable("output_table3.xlsx", "report1" => table, "report2" => table2)
+    XLSX.writetable("output_table4.xlsx", ["report1" => table, "report2" => table2])
+    for file in ["output_table4.xlsx", "output_table3.xlsx"]
+        try
+            f = XLSX.readxlsx(file)
+            result1 = Tables.columntable(XLSX.eachtablerow(f["report1"]))
+            result2 = Tables.columntable(XLSX.eachtablerow(f["report2"]))
+            @test isequal(table, result1)
+            @test isequal(table2, result2)
+        finally
+            rm(file)
+        end
     end
 
     @testset "Tables.jl with DataFrames" begin


### PR DESCRIPTION
Adds two additional methods for writing Tables.jl tables

`writetable!(sheet::Worksheet, tbl)` I think is a relatively obvious fill-in of the api.

`writetable(file, "sheet 1" => tbl1, "sheet 2" => tbl2)` may need discussed.  I proposed the pair syntax here to keep the existing functionality using keyword argument intact.