### PR TITLE
Writetable with AbstractString

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -56,7 +56,7 @@ struct CellDataFormat <: AbstractCellDataFormat
     id::UInt
 end
 
-const CellValueType = Union{String, Missing, Float64, Int, Bool, Dates.Date, Dates.Time, Dates.DateTime}
+const CellValueType = Union{AbstractString, Missing, Float64, Int, Bool, Dates.Date, Dates.Time, Dates.DateTime}
 
 # CellValue is a Julia type of a value read from a Spreadsheet.
 struct CellValue

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1136,15 +1136,16 @@ end
 @testset "writetable" begin
 
     @testset "single" begin
-        col_names = ["Integers", "Strings", "Floats", "Booleans", "Dates", "Times", "DateTimes"]
-        data = Vector{Any}(undef, 7)
+        col_names = ["Integers", "Strings", "AbstractStrings", "Floats", "Booleans", "Dates", "Times", "DateTimes"]
+        data = Vector{Any}(undef, 8)
         data[1] = [1, 2, missing, 4]
         data[2] = ["Hey", "You", "Out", "There"]
-        data[3] = [101.5, 102.5, missing, 104.5]
-        data[4] = [ true, false, missing, true]
-        data[5] = [ Date(2018, 2, 1), Date(2018, 3, 1), Date(2018,5,20), Date(2018, 6, 2)]
-        data[6] = [ Dates.Time(19, 10), Dates.Time(19, 20), Dates.Time(19, 30), Dates.Time(0, 0) ]
-        data[7] = [ Dates.DateTime(2018, 5, 20, 19, 10), Dates.DateTime(2018, 5, 20, 19, 20), Dates.DateTime(2018, 5, 20, 19, 30), Dates.DateTime(2018, 5, 20, 19, 40)]
+        data[3] = SubString.(["Hey", "You", "Out", "There"], 1, 2)
+        data[4] = [101.5, 102.5, missing, 104.5]
+        data[5] = [ true, false, missing, true]
+        data[6] = [ Date(2018, 2, 1), Date(2018, 3, 1), Date(2018,5,20), Date(2018, 6, 2)]
+        data[7] = [ Dates.Time(19, 10), Dates.Time(19, 20), Dates.Time(19, 30), Dates.Time(0, 0) ]
+        data[8] = [ Dates.DateTime(2018, 5, 20, 19, 10), Dates.DateTime(2018, 5, 20, 19, 20), Dates.DateTime(2018, 5, 20, 19, 30), Dates.DateTime(2018, 5, 20, 19, 40)]
 
         XLSX.writetable("output_table.xlsx", data, col_names, overwrite=true, sheetname="report", anchor_cell="B2")
         @test isfile("output_table.xlsx")


### PR DESCRIPTION
Current `writetable` implementation errors when a subtype of `AbstractString` which is not a `String` is used. Example is a column of whose `eltype isa SubString`.

Stacktrace of error:
```
julia> XLSX.writetable("output_file.xlsx", [SubString.(["test", "here", "there"], 1, 2)], ["SubString"]; overwrite=true)
ERROR: Unsupported datatype SubString{String} for writing data to Excel file. Supported data types are Union{Missing, Bool, Float64, Int64, Dates.Date, Dates.DateTime, Dates.Time, String} or XLSX.CellValue.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] setdata!(ws::XLSX.Worksheet, ref::XLSX.CellRef, value::SubString{String})
   @ XLSX ~/dev/XLSX_fork/src/write.jl:309
 [3] setindex!(ws::XLSX.Worksheet, v::SubString{String}, ref::XLSX.CellRef)
   @ XLSX ~/dev/XLSX_fork/src/write.jl:299
 [4] writetable!(sheet::XLSX.Worksheet, data::Vector{Vector{SubString{String}}}, columnnames::Vector{String}; anchor_cell::XLSX.CellRef)
   @ XLSX ~/dev/XLSX_fork/src/write.jl:419
 [5] writetable(filename::String, data::Vector{Vector{SubString{String}}}, columnnames::Vector{String}; overwrite::Bool, sheetname::String, anchor_cell::XLSX.CellRef)
   @ XLSX ~/dev/XLSX_fork/src/write.jl:604
 [6] top-level scope
   @ REPL[12]:1
```

Proposed Changes:
- [x] `String->AbstractString` in `CellValueType`
- [x] Test `SubString` in `writetable::single`