### PR TITLE
Write subtypes of AbstractStrings and Reals

### DIFF
--- a/src/XLSX.jl
+++ b/src/XLSX.jl
@@ -7,6 +7,7 @@ import Printf.@printf
 import ZipFile
 import EzXML
 import Tables
+import Base.convert
 
 # https://github.com/fhs/ZipFile.jl/issues/39
 if !hasmethod(Base.bytesavailable, Tuple{ZipFile.ReadableFile})

--- a/src/types.jl
+++ b/src/types.jl
@@ -56,7 +56,7 @@ struct CellDataFormat <: AbstractCellDataFormat
     id::UInt
 end
 
-const CellValueType = Union{String, Missing, Float64, Int, Bool, Dates.Date, Dates.Time, Dates.DateTime}
+const CellValueType = Union{AbstractString, Missing, Float64, Int, Bool, Dates.Date, Dates.Time, Dates.DateTime}
 
 # CellValue is a Julia type of a value read from a Spreadsheet.
 struct CellValue

--- a/src/types.jl
+++ b/src/types.jl
@@ -56,7 +56,7 @@ struct CellDataFormat <: AbstractCellDataFormat
     id::UInt
 end
 
-const CellValueType = Union{AbstractString, Missing, Float64, Int, Bool, Dates.Date, Dates.Time, Dates.DateTime}
+const CellValueType = Union{String, Missing, Float64, Int, Bool, Dates.Date, Dates.Time, Dates.DateTime}
 
 # CellValue is a Julia type of a value read from a Spreadsheet.
 struct CellValue

--- a/src/write.jl
+++ b/src/write.jl
@@ -294,6 +294,9 @@ function setdata!(ws::Worksheet, ref::CellRef, val::CellValue)
     setdata!(ws, cell)
 end
 
+# Convert AbstractString to concrete String
+setdata!(ws::Worksheet, ref::CellRef, val::AbstractString) = setdata!(ws, ref, CellValue(ws, convert(String, val)))
+
 setdata!(ws::Worksheet, row::Integer, col::Integer, val::CellValue) = setdata!(ws, CellRef(row, col), val)
 
 Base.setindex!(ws::Worksheet, v, ref) = setdata!(ws, ref, v)

--- a/src/write.jl
+++ b/src/write.jl
@@ -294,8 +294,9 @@ function setdata!(ws::Worksheet, ref::CellRef, val::CellValue)
     setdata!(ws, cell)
 end
 
-# Convert AbstractString to concrete String
+# convert AbstractTypes to concrete
 setdata!(ws::Worksheet, ref::CellRef, val::AbstractString) = setdata!(ws, ref, CellValue(ws, convert(String, val)))
+setdata!(ws::Worksheet, ref::CellRef, val::Real) = setdata!(ws, ref, CellValue(ws, convert(Float64, val)))
 
 setdata!(ws::Worksheet, row::Integer, col::Integer, val::CellValue) = setdata!(ws, CellRef(row, col), val)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -676,7 +676,7 @@ function check_test_data(data::Vector{S}, test_data::Vector{T}) where {S, T}
         if ismissing(test_value) || ( isa(test_value, AbstractString) && isempty(test_value) )
             @test ismissing(value) || ( isa(value, AbstractString) && isempty(value) )
         else
-            if isa(test_value, Float64) || isa(test_value, Rational)
+            if isa(test_value, Real)
                 @test isapprox(value, test_value)
             else
                 @test value == test_value
@@ -1136,8 +1136,8 @@ end
 @testset "writetable" begin
 
     @testset "single" begin
-        col_names = ["Integers", "Strings", "Floats", "Booleans", "Dates", "Times", "DateTimes", "AbstractStrings", "Reals"]
-        data = Vector{Any}(undef, 9)
+        col_names = ["Integers", "Strings", "Floats", "Booleans", "Dates", "Times", "DateTimes", "AbstractStrings", "Rational", "Irrationals"]
+        data = Vector{Any}(undef, 10)
         data[1] = [1, 2, missing, 4]
         data[2] = ["Hey", "You", "Out", "There"]
         data[3] = [101.5, 102.5, missing, 104.5]
@@ -1147,6 +1147,7 @@ end
         data[7] = [ Dates.DateTime(2018, 5, 20, 19, 10), Dates.DateTime(2018, 5, 20, 19, 20), Dates.DateTime(2018, 5, 20, 19, 30), Dates.DateTime(2018, 5, 20, 19, 40)]
         data[8] = SubString.(["Hey", "You", "Out", "There"], 1, 2)
         data[9] = [1//2, 1//3, missing, 22//3]
+        data[10] = [pi, sqrt(2), missing, sqrt(5)]
 
         XLSX.writetable("output_table.xlsx", data, col_names, overwrite=true, sheetname="report", anchor_cell="B2")
         @test isfile("output_table.xlsx")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -676,7 +676,7 @@ function check_test_data(data::Vector{S}, test_data::Vector{T}) where {S, T}
         if ismissing(test_value) || ( isa(test_value, AbstractString) && isempty(test_value) )
             @test ismissing(value) || ( isa(value, AbstractString) && isempty(value) )
         else
-            if isa(test_value, Float64)
+            if isa(test_value, Float64) || isa(test_value, Rational)
                 @test isapprox(value, test_value)
             else
                 @test value == test_value
@@ -1136,16 +1136,17 @@ end
 @testset "writetable" begin
 
     @testset "single" begin
-        col_names = ["Integers", "Strings", "AbstractStrings", "Floats", "Booleans", "Dates", "Times", "DateTimes"]
-        data = Vector{Any}(undef, 8)
+        col_names = ["Integers", "Strings", "Floats", "Booleans", "Dates", "Times", "DateTimes", "AbstractStrings", "Reals"]
+        data = Vector{Any}(undef, 9)
         data[1] = [1, 2, missing, 4]
         data[2] = ["Hey", "You", "Out", "There"]
-        data[3] = SubString.(["Hey", "You", "Out", "There"], 1, 2)
-        data[4] = [101.5, 102.5, missing, 104.5]
-        data[5] = [ true, false, missing, true]
-        data[6] = [ Date(2018, 2, 1), Date(2018, 3, 1), Date(2018,5,20), Date(2018, 6, 2)]
-        data[7] = [ Dates.Time(19, 10), Dates.Time(19, 20), Dates.Time(19, 30), Dates.Time(0, 0) ]
-        data[8] = [ Dates.DateTime(2018, 5, 20, 19, 10), Dates.DateTime(2018, 5, 20, 19, 20), Dates.DateTime(2018, 5, 20, 19, 30), Dates.DateTime(2018, 5, 20, 19, 40)]
+        data[3] = [101.5, 102.5, missing, 104.5]
+        data[4] = [ true, false, missing, true]
+        data[5] = [ Date(2018, 2, 1), Date(2018, 3, 1), Date(2018,5,20), Date(2018, 6, 2)]
+        data[6] = [ Dates.Time(19, 10), Dates.Time(19, 20), Dates.Time(19, 30), Dates.Time(0, 0) ]
+        data[7] = [ Dates.DateTime(2018, 5, 20, 19, 10), Dates.DateTime(2018, 5, 20, 19, 20), Dates.DateTime(2018, 5, 20, 19, 30), Dates.DateTime(2018, 5, 20, 19, 40)]
+        data[8] = SubString.(["Hey", "You", "Out", "There"], 1, 2)
+        data[9] = [1//2, 1//3, missing, 22//3]
 
         XLSX.writetable("output_table.xlsx", data, col_names, overwrite=true, sheetname="report", anchor_cell="B2")
         @test isfile("output_table.xlsx")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1136,15 +1136,16 @@ end
 @testset "writetable" begin
 
     @testset "single" begin
-        col_names = ["Integers", "Strings", "Floats", "Booleans", "Dates", "Times", "DateTimes"]
-        data = Vector{Any}(undef, 7)
+        col_names = ["Integers", "Strings", "AbstractStrings", "Floats", "Booleans", "Dates", "Times", "DateTimes"]
+        data = Vector{Any}(undef, 8)
         data[1] = [1, 2, missing, 4]
         data[2] = ["Hey", "You", "Out", "There"]
-        data[3] = [101.5, 102.5, missing, 104.5]
-        data[4] = [ true, false, missing, true]
-        data[5] = [ Date(2018, 2, 1), Date(2018, 3, 1), Date(2018,5,20), Date(2018, 6, 2)]
-        data[6] = [ Dates.Time(19, 10), Dates.Time(19, 20), Dates.Time(19, 30), Dates.Time(0, 0) ]
-        data[7] = [ Dates.DateTime(2018, 5, 20, 19, 10), Dates.DateTime(2018, 5, 20, 19, 20), Dates.DateTime(2018, 5, 20, 19, 30), Dates.DateTime(2018, 5, 20, 19, 40)]
+        data[3] = SubString.(["Hey", "You", "Out", "There"], 1, 2)
+        data[4] = [101.5, 102.5, missing, 104.5]
+        data[5] = [ true, false, missing, true]
+        data[6] = [ Date(2018, 2, 1), Date(2018, 3, 1), Date(2018,5,20), Date(2018, 6, 2)]
+        data[7] = [ Dates.Time(19, 10), Dates.Time(19, 20), Dates.Time(19, 30), Dates.Time(0, 0) ]
+        data[8] = [ Dates.DateTime(2018, 5, 20, 19, 10), Dates.DateTime(2018, 5, 20, 19, 20), Dates.DateTime(2018, 5, 20, 19, 30), Dates.DateTime(2018, 5, 20, 19, 40)]
 
         XLSX.writetable("output_table.xlsx", data, col_names, overwrite=true, sheetname="report", anchor_cell="B2")
         @test isfile("output_table.xlsx")


### PR DESCRIPTION
Proposed fix for #191.

Promote `AbstractString => String` and `Real => Float64` types in `set_data!`. Test handles rationals, irrationals, and substrings as examples.