### PR TITLE
Fix for #202

### DIFF
--- a/src/workbook.jl
+++ b/src/workbook.jl
@@ -73,13 +73,18 @@ function Base.show(io::IO, xf::XLSXFile)
     println(io, "-"^(21+1+13+1+13))
 
     for s in wb.sheets
-        name = s.name |> x -> length(x) > 20 ? x[1:20]*"…" : x
+        sheetname = s.name 
+        if textwidth(sheetname) > 20 
+            sheetname_index = eachindex(s.name)
+            sheetname = sheetname[collect(eachindex(s.name))[1:20]] * "…"
+        end
+
         if s.dimension != nothing
             rg = s.dimension
             _size = size(rg) |> x -> string(x[1], "x", x[2])
-            @printf(io, "%21s %-13s %-13s\n", name, _size, rg)
+            @printf(io, "%21s %-13s %-13s\n", sheetname, _size, rg)
         else
-            @printf(io, "%21s size unknown\n", name)
+            @printf(io, "%21s size unknown\n", sheetname)
         end
     end
 end

--- a/src/workbook.jl
+++ b/src/workbook.jl
@@ -75,7 +75,6 @@ function Base.show(io::IO, xf::XLSXFile)
     for s in wb.sheets
         sheetname = s.name 
         if textwidth(sheetname) > 20 
-            sheetname_index = eachindex(s.name)
             sheetname = sheetname[collect(eachindex(s.name))[1:20]] * "…"
         end
 


### PR DESCRIPTION
Should use `textwidth` and `eachindex` for dealing with text print 
Tested on my PC
[Book1.xlsx](https://github.com/felipenoris/XLSX.jl/files/9462244/Book1.xlsx)

```julia
julia> f = joinpath(@__DIR__, "Book1.xlsx")
julia> XLSX.readxlsx(f)
XLSXFile("Book1.xlsx") containing 2 Worksheets
            sheetname size          range        
-------------------------------------------------
하나둘셋넷다섯여섯일곱여덟아홉열열하나열… 1x1           A1:A1        
あいうえおかきくけこさしすせそなにぬねの… 1x1           A1:A1   
```
