### PR TITLE
Fix for #204 (deal with phonetic text)

### DIFF
--- a/src/sst.jl
+++ b/src/sst.jl
@@ -113,7 +113,9 @@ function unformatted_text(el::EzXML.Node) :: String
         end
 
         for ch in EzXML.eachelement(e)
-            gather_strings!(v, ch)
+            if EzXML.nodename(e) != "rPh"
+                gather_strings!(v, ch)
+            end 
         end
 
         nothing


### PR DESCRIPTION
This is fix for #204, to deal with phonetic text.

```Julia
julia> # Employment Status Survey / Statistical Tables(Time Series) / Statistical Tables(Time Series) from e-Stat (a portal site for Japanese Government Statistics)
       # https://www.e-stat.go.jp/en/stat-search/files?page=1&layout=datalist&toukei=00200532&tstat=000001116777&cycle=0&tclass1=000001116800&stat_infid=000031732265&tclass2val=0
       using XLSX, Downloads
       f = tempname()
       Downloads.download("https://www.e-stat.go.jp/en/stat-search/file-download?statInfId=000031732265&fileKind=0", f)
       XLSX.readxlsx(f)[1][:][1]

"第 １ 表  男女，就業状態別15歳以上人口"
# before fixing, the output was with phonetic text "第 １ 表  男女，就業状態別15歳以上人口ダイダンジョシュウギョウジョウタイベツサイイジョウジンコウ"
```