### PR TITLE
support reading from IO as well as a file path

### DIFF
--- a/src/relationship.jl
+++ b/src/relationship.jl
@@ -49,14 +49,14 @@ end
 
 function get_package_relationship_root(xf::XLSXFile) :: EzXML.Node
     xroot = xmlroot(xf, "_rels/.rels")
-    @assert EzXML.nodename(xroot) == "Relationships" "Malformed XLSX file $(xf.filepath). _rels/.rels root node name should be `Relationships`. Found $(EzXML.nodename(xroot))."
+    @assert EzXML.nodename(xroot) == "Relationships" "Malformed XLSX file $(xf.source). _rels/.rels root node name should be `Relationships`. Found $(EzXML.nodename(xroot))."
     @assert EzXML.namespaces(xroot) == Pair{String,String}[""=>"http://schemas.openxmlformats.org/package/2006/relationships"]
     return xroot
 end
 
 function get_workbook_relationship_root(xf::XLSXFile) :: EzXML.Node
     xroot = xmlroot(xf, "xl/_rels/workbook.xml.rels")
-    @assert EzXML.nodename(xroot) == "Relationships" "Malformed XLSX file $(xf.filepath). xl/_rels/workbook.xml.rels root node name should be `Relationships`. Found $(EzXML.nodename(xroot))."
+    @assert EzXML.nodename(xroot) == "Relationships" "Malformed XLSX file $(xf.source). xl/_rels/workbook.xml.rels root node name should be `Relationships`. Found $(EzXML.nodename(xroot))."
     @assert EzXML.namespaces(xroot) == Pair{String,String}[""=>"http://schemas.openxmlformats.org/package/2006/relationships"]
     return xroot
 end

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -43,9 +43,9 @@ Base.show(io::IO, state::SheetRowStreamIteratorState) = print(io, "SheetRowStrea
 
 # Opens a file for streaming.
 @inline function open_internal_file_stream(xf::XLSXFile, filename::String) :: Tuple{ZipFile.Reader, EzXML.StreamReader}
-    @assert internal_xml_file_exists(xf, filename) "Couldn't find $filename in $(xf.filepath)."
-    @assert isfile(xf.filepath) "Can't open internal file $filename for streaming because the XLSX file $(xf.filepath) was not found."
-    io = ZipFile.Reader(xf.filepath)
+    @assert internal_xml_file_exists(xf, filename) "Couldn't find $filename in $(xf.source)."
+    @assert xf.source isa IO || isfile(xf.source) "Can't open internal file $filename for streaming because the XLSX file $(xf.filepath) was not found."
+    io = ZipFile.Reader(xf.source)
 
     for f in io.files
         if f.name == filename
@@ -53,7 +53,7 @@ Base.show(io::IO, state::SheetRowStreamIteratorState) = print(io, "SheetRowStrea
         end
     end
 
-    error("Couldn't find $filename in $(xf.filepath).")
+    error("Couldn't find $filename in $(xf.source).")
 end
 
 @inline Base.isopen(s::SheetRowStreamIteratorState) = s.is_open

--- a/src/types.jl
+++ b/src/types.jl
@@ -249,7 +249,7 @@ sh = xf["mysheet"] # get a reference to a Worksheet
 ```
 """
 mutable struct XLSXFile <: MSOfficePackage
-    filepath::AbstractString
+    source::Union{AbstractString, IO}
     use_cache_for_sheet_data::Bool # indicates wether Worksheet.cache will be fed while reading worksheet cells.
     io::ZipFile.Reader
     io_is_open::Bool
@@ -260,10 +260,10 @@ mutable struct XLSXFile <: MSOfficePackage
     relationships::Vector{Relationship} # contains package level relationships
     is_writable::Bool # indicates wether this XLSX file can be edited
 
-    function XLSXFile(filepath::AbstractString, use_cache::Bool, is_writable::Bool)
-        check_for_xlsx_file_format(filepath)
-        io = ZipFile.Reader(filepath)
-        xl = new(filepath, use_cache, io, true, Dict{String, Bool}(), Dict{String, EzXML.Document}(), Dict{String, Vector{UInt8}}(), EmptyWorkbook(), Vector{Relationship}(), is_writable)
+    function XLSXFile(source::Union{AbstractString, IO}, use_cache::Bool, is_writable::Bool)
+        check_for_xlsx_file_format(source)
+        io = ZipFile.Reader(source)
+        xl = new(source, use_cache, io, true, Dict{String, Bool}(), Dict{String, EzXML.Document}(), Dict{String, Vector{UInt8}}(), EmptyWorkbook(), Vector{Relationship}(), is_writable)
         xl.workbook.package = xl
         finalizer(close, xl)
         return xl

--- a/src/workbook.jl
+++ b/src/workbook.jl
@@ -48,7 +48,7 @@ function getsheet(wb::Workbook, sheetname::String) :: Worksheet
             return ws
         end
     end
-    error("$(get_xlsxfile(wb).filepath) does not have a Worksheet named $sheetname.")
+    error("$(get_xlsxfile(wb).source) does not have a Worksheet named $sheetname.")
 end
 
 @inline getsheet(wb::Workbook, sheet_index::Int) :: Worksheet = wb.sheets[sheet_index]
@@ -67,7 +67,7 @@ function Base.show(io::IO, xf::XLSXFile)
     end
 
     wb = xf.workbook
-    print(io, "XLSXFile(\"$(basename(xf.filepath))\") ",
+    print(io, "XLSXFile(\"$(xf.source)\") ",
               "containing $(sheetcountstr(wb))\n")
     @printf(io, "%21s %-13s %-13s\n", "sheetname", "size", "range")
     println(io, "-"^(21+1+13+1+13))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,8 @@ data_directory = joinpath(dirname(pathof(XLSX)), "..", "data")
     ef_book_sparse_2 = XLSX.readxlsx(joinpath(data_directory, "book_sparse_2.xlsx"))
     XLSX.readxlsx(joinpath(data_directory, "missing_numFmtId.xlsx"))["Koldioxid (CO2)"][7,5]
 
+    @test open(joinpath(data_directory, "blank_ptbr_1904.xlsx")) do io XLSX.readxlsx(io) end isa XLSX.XLSXFile
+
     @test ef_Book1.source == joinpath(data_directory, "Book1.xlsx")
     @test length(keys(ef_Book1.data)) > 0
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,10 +16,10 @@ data_directory = joinpath(dirname(pathof(XLSX)), "..", "data")
     ef_book_sparse_2 = XLSX.readxlsx(joinpath(data_directory, "book_sparse_2.xlsx"))
     XLSX.readxlsx(joinpath(data_directory, "missing_numFmtId.xlsx"))["Koldioxid (CO2)"][7,5]
 
-    @test ef_Book1.filepath == joinpath(data_directory, "Book1.xlsx")
+    @test ef_Book1.source == joinpath(data_directory, "Book1.xlsx")
     @test length(keys(ef_Book1.data)) > 0
 
-    @test ef_Book_1904.filepath == joinpath(data_directory, "Book_1904.xlsx")
+    @test ef_Book_1904.source == joinpath(data_directory, "Book_1904.xlsx")
     @test length(keys(ef_Book_1904.data)) > 0
 
     @test !XLSX.isdate1904(ef_Book1)


### PR DESCRIPTION
If I have an an excel document in an IO Buffer (e.g. `Downloads.download` to an IOBuffer, not a file) it would be good to be to open this directly, and not have to start using tempfiles or something like that.

ZipFile already supports IO as well as file paths, so I just tried making the obvious changes and running `Pkg.test` to see if any issues pop up — everything seems to work as expected (no test failures), so I think this might be good to merge.