### PR TITLE
Fix lost formula references

### DIFF
--- a/src/XLSX.jl
+++ b/src/XLSX.jl
@@ -17,6 +17,7 @@ end
 const SPREADSHEET_NAMESPACE_XPATH_ARG = [ "xpath" => "http://schemas.openxmlformats.org/spreadsheetml/2006/main" ]
 
 include("types.jl")
+include("formula.jl")
 include("cellref.jl")
 include("sst.jl")
 include("stream.jl")

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -114,6 +114,10 @@ function Cell(c::EzXML.Node)
 
     return Cell(ref, t, s, v, f)
 end
+# Constructor with simple formula string for backward compatibility
+function Cell(ref::CellRef, datatype::String, style::String, value::String, formula::String)
+    return Cell(ref, datatype, style, value, Formula(formula))
+end
 
 @inline getdata(ws::Worksheet, empty::EmptyCell) = missing
 

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -58,7 +58,7 @@ function Cell(c::EzXML.Node)
 
     # iterate v and f elements
     local v::String = ""
-    local f::String = ""
+    local f::AbstractFormula = Formula("")
     local found_v::Bool = false
     local found_f::Bool = false
 
@@ -92,8 +92,22 @@ function Cell(c::EzXML.Node)
                 else
                     found_f = true
                 end
-
-                f = EzXML.nodecontent(c_child_element)
+                formula_string = EzXML.nodecontent(c_child_element)
+                f = if haskey(c_child_element, "ref")
+                    haskey(c_child_element, "si") || error("Expected shared formula to have an index. `si` attribute is missing: $c_child_element")
+                    ReferencedFormula(
+                        formula_string,
+                        parse(Int, c_child_element["si"]),
+                        c_child_element["ref"],
+                    )
+                elseif haskey(c_child_element, "t") && c_child_element["t"] == "shared"
+                    haskey(c_child_element, "si") || error("Expected shared formula to have an index. `si` attribute is missing: $c_child_element")
+                    FormulaReference(
+                        parse(Int, c_child_element["si"])
+                    )
+                else
+                    Formula(formula_string)
+                end
             end
         end
     end

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -93,7 +93,7 @@ function Cell(c::EzXML.Node)
                     found_f = true
                 end
                 formula_string = EzXML.nodecontent(c_child_element)
-                f = if haskey(c_child_element, "ref")
+                f = if haskey(c_child_element, "ref") && haskey(c_child_element, "t") && c_child_element["t"] == "shared"
                     haskey(c_child_element, "si") || error("Expected shared formula to have an index. `si` attribute is missing: $c_child_element")
                     ReferencedFormula(
                         formula_string,

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -1,20 +1,3 @@
-Base.:(==)(f1::AbstractFormula, f2::AbstractFormula) = false
-
-Base.:(==)(f1::Formula, f2::Formula) = f1.formula == f2.formula
-
-Base.:(==)(f1::ReferencedFormula, f2::Formula) = f1.formula == f2.formula
-Base.:(==)(f1::Formula, f2::ReferencedFormula) = f1.formula == f2.formula
-
-# WARNING: This is problematic because indexing is unique per sheet
-Base.:(==)(f1::Union{FormulaReference, ReferencedFormula}, f2::FormulaReference) = f1.id == f2.id 
-Base.:(==)(f1::FormulaReference, f2::ReferencedFormula) = f1.id == f2.id 
-
-Base.:(==)(f1::ReferencedFormula, f2::ReferencedFormula) = f1.id == f2.id && f1.formula == f2.formula
-
-Base.hash(f::Formula) = hash(f.formula)
-Base.hash(f::ReferencedFormula) = hash(f.formula) + hash(f.id) + hash(f.ref)
-Base.hash(f::FormulaReference) = hash(f.id)
-
 Base.isempty(f::Formula) = f.formula == ""
 Base.isempty(f::ReferencedFormula) = f.formula == ""
 Base.isempty(f::FormulaReference) = false # always links to another formula

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -2,10 +2,14 @@ Base.:(==)(f1::AbstractFormula, f2::AbstractFormula) = false
 
 Base.:(==)(f1::Formula, f2::Formula) = f1.formula == f2.formula
 
-Base.:(==)(f1::Union{Formula, ReferencedFormula}, f2::Union{Formula, ReferencedFormula}) = f1.formula == f2.formula
+Base.:(==)(f1::ReferencedFormula, f2::Formula) = f1.formula == f2.formula
+Base.:(==)(f1::Formula, f2::ReferencedFormula) = f1.formula == f2.formula
 
 # WARNING: This is problematic because indexing is unique per sheet
-Base.:(==)(f1::Union{FormulaReference, ReferencedFormula}, f2::Union{FormulaReference, ReferencedFormula}) = f1.id == f2.id 
+Base.:(==)(f1::Union{FormulaReference, ReferencedFormula}, f2::FormulaReference) = f1.id == f2.id 
+Base.:(==)(f1::FormulaReference, f2::ReferencedFormula) = f1.id == f2.id 
+
+Base.:(==)(f1::ReferencedFormula, f2::ReferencedFormula) = f1.id == f2.id && f1.formula == f2.formula
 
 Base.hash(f::Formula) = hash(f.formula)
 Base.hash(f::ReferencedFormula) = hash(f.formula) + hash(f.id) + hash(f.ref)

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -1,0 +1,16 @@
+Base.:(==)(f1::AbstractFormula, f2::AbstractFormula) = false
+
+Base.:(==)(f1::Formula, f2::Formula) = f1.formula == f2.formula
+
+Base.:(==)(f1::Union{Formula, ReferencedFormula}, f2::Union{Formula, ReferencedFormula}) = f1.formula == f2.formula
+
+# WARNING: This is problematic because indexing is unique per sheet
+Base.:(==)(f1::Union{FormulaReference, ReferencedFormula}, f2::Union{FormulaReference, ReferencedFormula}) = f1.id == f2.id 
+
+Base.hash(f::Formula) = hash(f.formula)
+Base.hash(f::ReferencedFormula) = hash(f.formula) + hash(f.id) + hash(f.ref)
+Base.hash(f::FormulaReference) = hash(f.id)
+
+Base.isempty(f::Formula) = f.formula == ""
+Base.isempty(f::ReferencedFormula) = f.formula == ""
+Base.isempty(f::FormulaReference) = false # always links to another formula

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,6 +33,31 @@ struct CellRef
     column_number::Int
 end
 
+abstract type AbstractFormula end
+
+"""
+A default formula simply storing the formula string.
+"""
+struct Formula <: AbstractFormula
+    formula::String
+end
+
+"""
+The formula in this cell was defined somewhere else; we simply reference its ID.
+"""
+struct FormulaReference <: AbstractFormula
+    id::Int
+end
+
+"""
+Formula that is defined once and referenced in all cells given by the cell range given in `ref`.
+"""
+struct ReferencedFormula <: AbstractFormula
+    formula::String
+    id::Int
+    ref::String # actually a CellRange, but defined later --> change if at some point we want to actively change formulae
+end
+
 abstract type AbstractCell end
 
 mutable struct Cell <: AbstractCell
@@ -40,7 +65,7 @@ mutable struct Cell <: AbstractCell
     datatype::String
     style::String
     value::String
-    formula::String
+    formula::AbstractFormula
 end
 
 struct EmptyCell <: AbstractCell


### PR DESCRIPTION
Some formulas are defined by the formula strings alone
```
<c r="C1">
  <f>SUM(A1:B1)</f>
  <v>2</v>
</c>
```
and those are handled fine. However, if one "drags" a formula over multiple cells, the formula is only stored once:
```
<c r="C2">
  <f t="shared" ref="C2:C4" si="0">SUM(A2:B2)</f>
  <v>4</v>
</c>
```
and the rest of the cells reference this formula:
```
<c r="C3">
  <f t="shared" si="0"/>
  <v>6</v>
</c>
```
Since there is no content in these `<f>` elements, the formula is currently lost when re-constructing the XLSX file, and only the values remain.

With the proposed changes (breaking only for those who really use the internals), these formulas would be correctly reconstructed - at least as long as none of the formula cells are overwritten by something else.
Actually one would have to keep track of referencing and referenced formula cells to make sure no changes occur - I have not tested how Excel complains when opening a damaged file...

The changes should resolve issue #159 .