### PR TITLE
Add `const`s for Excel max sheet size and `@assert` them in `writetable!`

### DIFF
--- a/src/XLSX.jl
+++ b/src/XLSX.jl
@@ -15,6 +15,8 @@ if !hasmethod(Base.bytesavailable, Tuple{ZipFile.ReadableFile})
 end
 
 const SPREADSHEET_NAMESPACE_XPATH_ARG = [ "xpath" => "http://schemas.openxmlformats.org/spreadsheetml/2006/main" ]
+const EXCEL_MAX_COLS = 16_384     # total columns supported by Excel per sheet
+const EXCEL_MAX_ROWS = 1_048_576  # total rows supported by Excel per sheet (including headers)
 
 include("types.jl")
 include("formula.jl")

--- a/src/cellref.jl
+++ b/src/cellref.jl
@@ -30,7 +30,7 @@ end
 
 # Converts column number to a column name. See also XLSX.decode_column_number.
 function encode_column_number(column_number::Int) :: String
-    @assert column_number > 0 && column_number <= 16384 "Column number should be in the range from 1 to 16384."
+    @assert column_number > 0 && column_number <= EXCEL_MAX_COLS "Column number should be in the range from 1 to 16384."
 
     third_letter_sequence = div(column_number - 26 - 1, 26*26)
     column_number = column_number - third_letter_sequence*(26*26)
@@ -69,7 +69,7 @@ function is_valid_column_name(n::AbstractString) :: Bool
     end
 
     column_number = decode_column_number(n)
-    if column_number < 1 || column_number > 16384
+    if column_number < 1 || column_number > EXCEL_MAX_COLS
         return false
     end
 
@@ -103,7 +103,7 @@ function is_valid_cellname(n::AbstractString) :: Bool
 
     column_name, row = split_cellname(n)
 
-    if row < 1 || row > 1048576
+    if row < 1 || row > EXCEL_MAX_ROWS
         return false
     end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -473,7 +473,9 @@ function writetable!(sheet::Worksheet, data, columnnames; anchor_cell::CellRef=C
     col_count = length(data)
     @assert col_count == length(columnnames) "Column count mismatch between `data` ($col_count columns) and `columnnames` ($(length(columnnames)) columns)."
     @assert col_count > 0 "Can't write table with no columns."
+    @assert col_count <= EXCEL_MAX_COLS "`data` contains $col_count columns, but Excel only supports up to $EXCEL_MAX_COLS; must reduce `data` size"
     row_count = length(data[1])
+    @assert row_count <= EXCEL_MAX_ROWS-1 "`data` contains $row_count rows, but Excel only supports up to $(EXCEL_MAX_ROWS-1); must reduce `data` size"
     if col_count > 1
         for c in 2:col_count
             @assert length(data[c]) == row_count "Row count mismatch between column 1 ($row_count rows) and column $c ($(length(data[c])) rows)."

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,8 +127,8 @@ end
     cn = XLSX.CellRef("XFD1048576")
     @test string(cn) == "XFD1048576"
     @test XLSX.column_name(cn) == "XFD"
-    @test XLSX.row_number(cn) == 1048576
-    @test XLSX.column_number(cn) == 16384
+    @test XLSX.row_number(cn) == XLSX.EXCEL_MAX_ROWS
+    @test XLSX.column_number(cn) == XLSX.EXCEL_MAX_COLS
 
     v_column_numbers = [1
     ,    15


### PR DESCRIPTION
This fixes #246.

I found these limits hardcoded in other locations besides `write.jl`, so I replaced them with the `const` variables everywhere they appear.

MWE:
```julia
julia> using XLSX, DataFrames

julia> file = normpath(homedir(), "Downloads/test.xlsx");

julia> df = DataFrame(Symbol.(1:16_385) .=> "data")
1×16385 DataFrame
 Row │ 1       2       3       4       5       6       7       8       9       10      11  ⋯
     │ String  String  String  String  String  String  String  String  String  String  Str ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────
   1 │ data    data    data    data    data    data    data    data    data    data    dat ⋯

julia> df2 = DataFrame(x=1:1_048_576)
1048576×1 DataFrame
     Row │ x       
         │ Int64
─────────┼─────────
       1 │       1
       2 │       2
       3 │       3
    ⋮    │    ⋮

julia> XLSX.writetable(file, df, overwrite=true)
ERROR: AssertionError: `data` contains 16385 columns, but Excel only supports up to 16384; must reduce `data` size

julia> XLSX.writetable(file, df2, overwrite=true)
ERROR: AssertionError: `data` contains 1048576 rows, but Excel only supports up to 1048575; must reduce `data` size
```

Note that `df2` needs to fail at `row_count==1_048_576` rows because the column header puts it over the limit.

I would need help formalizing this MWE into tests if that is required. 