### PR TITLE
Faster writing using ZipArchives.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
           - '1.6'
           - '1.7'
           - '1.8'
           - '1.9'
           - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -11,13 +11,15 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 EzXML = "1"
 Tables = "1"
+ZipArchives = "2"
 ZipFile = "0.8, 0.9, 0.10"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/XLSX.jl
+++ b/src/XLSX.jl
@@ -5,6 +5,7 @@ import Artifacts
 import Dates
 import Printf.@printf
 import ZipFile
+import ZipArchives
 import EzXML
 import Tables
 import Base.convert


### PR DESCRIPTION
Here is a simple benchmark:

This PR: 2.317752   seconds (9.40 M allocations: 623.127 MiB, 23.31% gc time)
master: 11.811335 seconds (52.20 M allocations: 23.567 GiB, 24.20% gc time)
```julia
using XLSX

function create_excel_file(N)
    # Create an in-memory buffer for the Excel file
    io = IOBuffer()
    XLSX.openxlsx(io, mode="w") do xf
        sheet = xf[1]
        XLSX.writetable!(sheet, [randn(N), rand(1:100, N)], ["column_1", "column_2"])
    end
    return take!(io)
end

@time create_excel_file(200000);
@time create_excel_file(200000);
```

ZipArchives.jl requires Julia 1.6, so I increased the Julia compact.