### PR TITLE
support files without default namespace

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -269,7 +269,12 @@ function open_or_read_xlsx(source::Union{IO, AbstractString}, read_files::Bool, 
 end
 
 function get_default_namespace(r::EzXML.Node) :: String
-    for (prefix, ns) in EzXML.namespaces(r)
+    nss = EzXML.namespaces(r)
+    # in case that only one namespace is defined, assume that it is the default one
+    # even if it has a prefix
+    length(nss) == 1 && return nss[1][2]
+    # otherwise, look for the default namespace (without prefix)
+    for (prefix, ns) in nss
         if prefix == ""
             return ns
         end


### PR DESCRIPTION
I have an xlsx file that is generated by a website and can be read by both Excel and openpyxl.
However, I receive a "no node name" error when trying to parse the file with XLSX.
Unfortunately, I am not able to share the file at the moment.
But I succeeded in finding out the underlying root cause.

The file uses a non-default namespace, therefore the node names were prefixed with the namespace ("x:row" instead of "row"). Furthermore, there was no default namespace included in the worksheets styles, but only the namespace `"x"=>"http://schemas.openxmlformats.org/spreadsheetml/2006/main"`

This PR splits off the namespace for nodename checks and accepts a single namespace for assertion.
However, there is no checking for the correct namespace. But since there is only one namespace present, it is probably ok to handle the namespace this way.
