### PR TITLE
update docs for required Julia version

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,7 +16,7 @@ This package follows the EMCA-376 to parse and generate XLSX files.
 
 ## Requirements
 
-* Julia v1.3
+* Julia v1.6
 
 * Linux, macOS or Windows.
 


### PR DESCRIPTION
I forgot to update the docs in #266 when the required Julia version changed to v1.6