### PR TITLE
Update table.jl:  promoting type for columns mixing integer and float values

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -409,7 +409,11 @@ function infer_eltype(v::Vector{Any})
             hasmissing = true
         else
             if t != Any && typeof(v[i]) != t
-                return Any
+                t = promote_type(t, typeof(v[i]))
+                if t == Any
+                    return t
+                end
+                # return Any
             else
                 t = typeof(v[i])
             end


### PR DESCRIPTION
By referring to https://github.com/felipenoris/XLSX.jl/issues/192 this PR applies the `promote_type` function to infer the type of a column containing both integer and float values. 