### PR TITLE
Remove the gc call in write.jl

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -83,8 +83,6 @@ function writexlsx(output_source::Union{AbstractString, IO}, xf::XLSXFile; overw
             print(xlsx, generate_sst_xml_string(get_sst(xf)))
         end
     end
-    # fix libuv issue on windows (#42)
-    @static Sys.iswindows() ? GC.gc() : nothing
     nothing
 end
 


### PR DESCRIPTION
This gc call was added in Windows only, apparently in response to issue #42.

The consequence was that `writexlsx()` was much slower, with 97% of time spent on gc (in my use case).

Deleting this line speeds up `writexlsx()` forty-fold and XLSX still passes all tests.

Not sure what, if any, downsides there might be in other use cases.

See [this Discourse thread](https://discourse.julialang.org/t/xlsxwrite-spends-excessive-time-in-gc/120687).