### PR TITLE
Remove GC.gc call from read.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,13 +12,11 @@ EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"
-ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 EzXML = "1"
 Tables = "1"
 ZipArchives = "2"
-ZipFile = "0.8, 0.9, 0.10"
 julia = "1.6"
 
 [extras]

--- a/src/XLSX.jl
+++ b/src/XLSX.jl
@@ -4,7 +4,6 @@ module XLSX
 import Artifacts
 import Dates
 import Printf.@printf
-import ZipFile
 import ZipArchives
 import EzXML
 import Tables
@@ -33,5 +32,7 @@ include("worksheet.jl")
 include("cell.jl")
 include("styles.jl")
 include("write.jl")
+
+
 
 end # module XLSX

--- a/src/XLSX.jl
+++ b/src/XLSX.jl
@@ -9,12 +9,7 @@ import EzXML
 import Tables
 import Base.convert
 
-# https://github.com/fhs/ZipFile.jl/issues/39
-if !hasmethod(Base.bytesavailable, Tuple{ZipFile.ReadableFile})
-    Base.bytesavailable(f::ZipFile.ReadableFile) = f.uncompressedsize - f._pos
-end
-
-const SPREADSHEET_NAMESPACE_XPATH_ARG = [ "xpath" => "http://schemas.openxmlformats.org/spreadsheetml/2006/main" ]
+const SPREADSHEET_NAMESPACE_XPATH_ARG = ["xpath" => "http://schemas.openxmlformats.org/spreadsheetml/2006/main"]
 const EXCEL_MAX_COLS = 16_384     # total columns supported by Excel per sheet
 const EXCEL_MAX_ROWS = 1_048_576  # total rows supported by Excel per sheet (including headers)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -284,7 +284,7 @@ sh = xf["mysheet"] # get a reference to a Worksheet
 mutable struct XLSXFile <: MSOfficePackage
     source::Union{AbstractString, IO}
     use_cache_for_sheet_data::Bool # indicates whether Worksheet.cache will be fed while reading worksheet cells.
-    io::ZipFile.Reader
+    io::ZipArchives.ZipReader
     io_is_open::Bool
     files::Dict{String, Bool} # maps filename => isread bool
     data::Dict{String, EzXML.Document} # maps filename => XMLDocument
@@ -295,7 +295,7 @@ mutable struct XLSXFile <: MSOfficePackage
 
     function XLSXFile(source::Union{AbstractString, IO}, use_cache::Bool, is_writable::Bool)
         check_for_xlsx_file_format(source)
-        io = ZipFile.Reader(source)
+        io = ZipArchives.ZipReader(read(source))
         xl = new(source, use_cache, io, true, Dict{String, Bool}(), Dict{String, EzXML.Document}(), Dict{String, Vector{UInt8}}(), EmptyWorkbook(), Vector{Relationship}(), is_writable)
         xl.workbook.package = xl
         finalizer(close, xl)

--- a/src/types.jl
+++ b/src/types.jl
@@ -194,7 +194,7 @@ Implementations: SheetRowStreamIterator, WorksheetCache.
 abstract type SheetRowIterator end
 
 mutable struct SheetRowStreamIteratorState
-    zip_io::ZipFile.Reader
+    zip_io::ZipArchives.ZipReader
     xml_stream_reader::EzXML.StreamReader
     is_open::Bool # indicated if zip_io and xml_stream_reader are opened
     row::Int # number of current row. It´s set to 0 in the start state.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1354,14 +1354,21 @@ end
         @test dt_read.column_labels == dt.column_labels
         @test dt_read.column_label_index == dt.column_label_index
     end
+end
     
-    # delete files created by this testset
-    delete_files = ["output_table.xlsx", "output_tables.xlsx"]
-    for f in delete_files
-        isfile(f) && rm(f)
+@testset "rm after read" begin
+    @testset "with readtable" begin
+        f = "output_table.xlsx"
+        dtable = XLSX.readtable(f, "report", "F")
+        @test isfile(f) && rm(f)==nothing
+    end
+    @testset "with readdata" begin
+        f = "output_tables.xlsx"
+        dtable = XLSX.readdata(f, "REPORT_A", "A1:B3")
+        @test isfile(f) && rm(f)==nothing
     end
 end
-
+ 
 @testset "Styles" begin
 
     using XLSX: CellValue, id, getcell, setdata!, CellRef


### PR DESCRIPTION
It was necessary to enable cache on both readdata() and readtable() to make this to work.