### PR TITLE
Replace some slow searches with `haskey` on a `Dict`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,13 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          show-versioninfo: true
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
         continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-runtest@v1
@@ -55,7 +47,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'

--- a/src/cellformats.jl
+++ b/src/cellformats.jl
@@ -2140,8 +2140,6 @@ function getRowHeight(ws::Worksheet, cellref::CellRef)::Union{Nothing,Real}
         if r.row == cellref.row_number
             if haskey(ws.cache.row_ht, r.row)
                 return ws.cache.row_ht[r.row]
-            else
-                return nothing
             end
         end
     end

--- a/src/cellformats.jl
+++ b/src/cellformats.jl
@@ -2098,10 +2098,8 @@ function setRowHeight(ws::Worksheet, rng::CellRange; height::Union{Nothing,Real}
     end
     for r in eachrow(ws)
         if r.row in top:bottom
-            if r.row ∈ ws.cache.rows_in_cache
-                if haskey(ws.cache.row_ht, r.row)
-                    ws.cache.row_ht[r.row] = padded_height
-                end
+            if haskey(ws.cache.row_ht, r.row)
+                ws.cache.row_ht[r.row] = padded_height
             end
         end
     end
@@ -2140,12 +2138,10 @@ function getRowHeight(ws::Worksheet, cellref::CellRef)::Union{Nothing,Real}
 
     for r in eachrow(ws)
         if r.row == cellref.row_number
-            if r.row ∈ ws.cache.rows_in_cache
-                if haskey(ws.cache.row_ht, r.row)
-                    return ws.cache.row_ht[r.row]
-                else
-                    return nothing
-                end
+            if haskey(ws.cache.row_ht, r.row)
+                return ws.cache.row_ht[r.row]
+            else
+                return nothing
             end
         end
     end

--- a/src/worksheet.jl
+++ b/src/worksheet.jl
@@ -239,7 +239,7 @@ function getcell(ws::Worksheet, single::CellRef) :: AbstractCell
     # Access cache directly if it exists and if file `isread` - much faster!
     if is_cache_enabled(ws) && ws.cache !== nothing
         if haskey(get_xlsxfile(ws).files, "xl/worksheets/sheet$(ws.sheetId).xml") && get_xlsxfile(ws).files["xl/worksheets/sheet$(ws.sheetId).xml"] == true
-            if single.row_number ∈ ws.cache.rows_in_cache
+            if haskey(ws.cache.cells, single.row_number)
                 if haskey(ws.cache.cells[single.row_number], single.column_number)
                     return ws.cache.cells[single.row_number][single.column_number]
                 end


### PR DESCRIPTION
I'm assuming here that `row ∈ ws.cache.rows_in_cache` is equivalent to `haskey(ws.cache.row_ht, row)` and `haskey(ws.cache.cells, row)`, so let me know if this isn't always true.

This significantly speeds up writing. Looking at the benchmark from https://github.com/felipenoris/XLSX.jl/pull/266

This PR: 3.56 seconds (33.41 M allocations: 1.616 GiB, 46.23% gc time, 0.11% compilation time)
master: 16.58 seconds (33.41 M allocations: 1.616 GiB, 7.42% gc time, 0.02% compilation time)
```julia
using XLSX

function create_excel_file(N)
    # Create an in-memory buffer for the Excel file
    io = IOBuffer()
    XLSX.openxlsx(io, mode="w") do xf
        sheet = xf[1]
        XLSX.writetable!(sheet, [randn(N), rand(1:100, N)], ["column_1", "column_2"])
    end
    return take!(io)
end

@time create_excel_file(200000);
@time create_excel_file(200000);
```

