### PR TITLE
Avoid converting data to a `String` in `zip_readentry`

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -445,7 +445,7 @@ function internal_xml_file_read(xf::XLSXFile, filename::String) :: XML.Node
     if !internal_xml_file_isread(xf, filename)
 
         try
-            xf.data[filename] = XML.parse(XML.Node, (ZipArchives.zip_readentry(xf.io, filename, String)))
+            xf.data[filename] = XML.Node(XML.Raw(ZipArchives.zip_readentry(xf.io, filename)))
             xf.files[filename] = true # set file as read
         catch err
             @error("Failed to parse internal XML file `$filename`")

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -50,12 +50,7 @@ Base.show(io::IO, state::SheetRowStreamIteratorState) = print(io, "SheetRowStrea
 @inline function open_internal_file_stream(xf::XLSXFile, filename::String) :: XML.LazyNode
     @assert internal_xml_file_exists(xf, filename) "Couldn't find $filename in $(xf.source)."
     @assert xf.source isa IO || isfile(xf.source) "Can't open internal file $filename for streaming because the XLSX file $(xf.filepath) was not found."
-
-    if filename in ZipArchives.zip_names(xf.io)
-        return XML.parse(XML.LazyNode, ZipArchives.zip_readentry(xf.io, filename, String))
-    end 
-
-    error("Couldn't find $filename in $(xf.source).")
+    XML.LazyNode(XML.Raw(ZipArchives.zip_readentry(xf.io, filename)))
 end
 
 # Creates a reader for row elements in the Worksheet's XML.


### PR DESCRIPTION
This avoids making two unnecessary copies of the data, one in [`ZipArchives`](https://github.com/JuliaIO/ZipArchives.jl/blob/8e931c906fe86a4b8a05456068fbe8f31b77cd17/src/reader.jl#L360) to convert from `Vector{UInt8}` to `String`, and one in [`XML`](https://github.com/JuliaComputing/XML.jl/blob/ff0ee250cefbc7f790ae35ac1908e647d34d85f7/src/raw.jl#L76) to convert from `String` back to `Vector{UInt8}`.