### PR TITLE
Fix broken ECMA-376 links in docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Package documentation is hosted at https://felipenoris.github.io/XLSX.jl/stable.
 
 * [ECMA Open XML White Paper](https://www.ecma-international.org/news/TC45_current_work/OpenXML%20White%20Paper.pdf)
 
-* [ECMA-376](https://www.ecma-international.org/publications/standards/Ecma-376.htm)
+* [ECMA-376](https://ecma-international.org/publications-and-standards/standards/ecma-376/)
 
 * [Excel file limits](https://support.office.com/en-gb/article/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ Internally, an Excel XLSX file is just a
 [Zip](https://en.wikipedia.org/wiki/Zip_(file_format)) file with a set of
 [XML](https://en.wikipedia.org/wiki/XML) files inside.
 The formats for these XML files are described in
-the [Standard ECMA-376](https://www.ecma-international.org/publications/standards/Ecma-376.htm).
+the [Standard ECMA-376](https://ecma-international.org/publications-and-standards/standards/ecma-376/).
 
 This package follows the EMCA-376 to parse and generate XLSX files.
 


### PR DESCRIPTION
Closes #305 by updating the ecma-376 links in the project `README.md`  and docs `docs/src/index.md` to match the working link in the resources section at the bottom of of the docs index page.