### PR TITLE
Fixed the issue with Unicode in index

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -383,7 +383,8 @@ function parse_workbook!(xf::XLSXFile)
                     elseif is_valid_fixed_sheet_cellrange(defined_value_string) || is_valid_sheet_cellrange(defined_value_string)
                         defined_value = SheetCellRange(defined_value_string)
                     elseif occursin(r"^\".*\"$", defined_value_string) # is enclosed by quotes
-                        defined_value = defined_value_string[2:end-1] # remove enclosing quotes
+                        local valid_indices = collect(eachindex(defined_value_string))
+                        defined_value = defined_value_string[valid_indices[2:length(valid_indices)-1]] # remove enclosing quotes
                         if isempty(defined_value)
                             defined_value = missing
                         end


### PR DESCRIPTION
If the string is Unicode, then some characters take more than one space and there are fewer valid indices:

For example, "α3" has three indices, 1 and 3 (2 does not exist because α takes up two bytes)

The pull request fixes the issue