### PR TITLE
Address issue 318

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ PrecompileTools = "1"
 Random = "1.10.0"
 Tables = "1"
 UUIDs = "1.8"
-XML = "0.3.7"
+XML = "0.3.8"
 ZipArchives = "2.5"
 julia = "1.8"
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -284,9 +284,7 @@ end
 
 !!! warning
 
-    The `read-write` mode is known occasionally to produce some data loss. See [#159](https://github.com/felipenoris/XLSX.jl/issues/159) (now fixed!)
-
-    Simple data should work fine. Users are advised to use this feature with caution when working with charts.
+    Using do-block syntax in "rw" mode will overwrite the file you read in with the modified data when the do block ends. Care is needed to ensure data are not inadvertantly overwritten, especially if the xlsx file contains any elements that `XLSX2.jl` cannot process (such as charts, pivot tables, etc), but that would otherwise be preserved if not overwritten. You may avoid this risk by choosing to open files in "rw" mode without using do-block syntax, in which case it becomes necessary explicitly to write the `XLSXFile` out again, providing the option to write to another file name.
 
 ### Export Tabular Data from a Worksheet
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -284,7 +284,7 @@ end
 
 !!! warning
 
-    Using do-block syntax in "rw" mode will overwrite the file you read in with the modified data when the do block ends. Care is needed to ensure data are not inadvertantly overwritten, especially if the xlsx file contains any elements that `XLSX2.jl` cannot process (such as charts, pivot tables, etc), but that would otherwise be preserved if not overwritten. You may avoid this risk by choosing to open files in "rw" mode without using do-block syntax, in which case it becomes necessary explicitly to write the `XLSXFile` out again, providing the option to write to another file name.
+    Using do-block syntax in "rw" mode will overwrite the file you read in with the modified data when the do block ends. Care is needed to ensure data are not inadvertantly overwritten, especially if the xlsx file contains any elements that `XLSX.jl` cannot process (such as charts, pivot tables, etc), but that would otherwise be preserved if not overwritten. You may avoid this risk by choosing to open files in "rw" mode without using do-block syntax, in which case it becomes necessary explicitly to write the `XLSXFile` out again, providing the option to write to another file name.
 
 ### Export Tabular Data from a Worksheet
 

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -33,7 +33,7 @@ function find_t_node_recursively(n::XML.LazyNode) :: Union{Nothing, XML.LazyNode
     return nothing
 end
 
-function Cell(c::XML.LazyNode, ws::Worksheet) :: Union{Cell, EmptyCell}
+function Cell(c::XML.LazyNode, ws::Worksheet; mylock::Union{ReentrantLock,Nothing}=nothing) :: Union{Cell, EmptyCell}
     # c (Cell) element is defined at section 18.3.1.4
     # t (Cell Data Type) is an enumeration representing the cell's data type. The possible values for this attribute are defined by the ST_CellType simple type (§18.18.11).
     # s (Style Index) is the index of this cell's style. Style records are stored in the Styles Part.
@@ -77,25 +77,9 @@ function Cell(c::XML.LazyNode, ws::Worksheet) :: Union{Cell, EmptyCell}
                 else
                     ft=("<si>\n  "*join(XML.write.(XML.children(c_child_element)), "\n")*"\n</si>")
                     t = "s"
-                    v = string(add_shared_string!(get_workbook(ws), uft, ft))
+                    v = string(add_shared_string!(get_workbook(ws), uft, ft; mylock))
                 end
-#                ws.sst_count+=1
-#                # old code, kept for reference
-#                t_node = find_t_node_recursively(c_child_element)
-#                if t_node !== nothing
-#                    c = XML.children(t_node)
-#                    if length(c) == 0
-#                        v = ""
-#                    elseif length(c) == 1
-#                        v= XML.value(c[1])
-#                    else
-#                        throw(XLSXError("Too many children in `t` node. Expected >=1, found: $(length(c))"))
-#                    end
-#                end
-#            else
-#                throw(XLSXError("Expected `is` node inside inlineStr cell. Found: `$(XML.tag(c_child_element))`"))
             end
-
         else
             if XML.tag(c_child_element) == "v"
                 if found_v # we should have only one v element

--- a/src/conditional-formats.jl
+++ b/src/conditional-formats.jl
@@ -673,7 +673,7 @@ Valid values for the `operator` keyword are the following:
 
 Default keyowrds are `operator="TopN"` and `value="10"`.
     
-Multiple conditional formats may be applied to the smae or overlapping cell ranges. 
+Multiple conditional formats may be applied to the same or overlapping cell ranges. 
 If `stopIfTrue=true` the first condition that is met will be applied but all subsequent 
 conditional formats for that cell will be skipped. If `stopIfTrue=false` (default) all 
 relevant conditional formats will be applied to the cell in turn.

--- a/src/read.jl
+++ b/src/read.jl
@@ -133,9 +133,11 @@ The `mode` argument controls how the file is opened. The following modes are all
 
 !!! warning
 
-    The `rw` mode is known occasionally to produce some data loss. See [#159](https://github.com/felipenoris/XLSX.jl/issues/159). (Now fixed!)
-
-    Simple data should work fine. Users are advised to use this feature with caution when working with charts.
+    Using do-block syntax in "rw" mode will overwrite the file you read in with the modified data when the do block ends.
+    Care is needed to ensure data are not inadvertantly overwritten, especially if the xlsx file contains any elements 
+    that `XLSX2.jl` cannot process (such as charts, pivot tables, etc), but that would otherwise be preserved if not 
+    overwritten. You may avoid this risk by choosing to open files in "rw" mode without using do-block syntax, in which 
+    case it becomes necessary explicitly to write the `XLSXFile` out again, providing the option to write to another file name.
 
 # Arguments
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -622,12 +622,7 @@ function load_files!(xf::XLSXFile; pass::Int)
                         rid=get_relationship_id_by_target(wb, file.name)
                         for sheet in wb.sheets
                             if sheet.relationship_id == rid
-                                if isnothing(findfirst(Vector{UInt8}("\"inlineStr\""), file.raw.data))
-                                    nth=Threads.nthreads() # multi-threaded if no inlineStrings are present
-                                else
-                                    nth=1 # single threaded if inlineStrings are present to avoid non-threadsafe access to shared string table
-                                end
-                                first_cache_fill!(sheet, XML.LazyNode(file.raw), nth)
+                                first_cache_fill!(sheet, XML.LazyNode(file.raw), Threads.nthreads())
                             end
                         end
                     end

--- a/src/read.jl
+++ b/src/read.jl
@@ -135,7 +135,7 @@ The `mode` argument controls how the file is opened. The following modes are all
 
     Using do-block syntax in "rw" mode will overwrite the file you read in with the modified data when the do block ends.
     Care is needed to ensure data are not inadvertantly overwritten, especially if the xlsx file contains any elements 
-    that `XLSX2.jl` cannot process (such as charts, pivot tables, etc), but that would otherwise be preserved if not 
+    that `XLSX.jl` cannot process (such as charts, pivot tables, etc), but that would otherwise be preserved if not 
     overwritten. You may avoid this risk by choosing to open files in "rw" mode without using do-block syntax, in which 
     case it becomes necessary explicitly to write the `XLSXFile` out again, providing the option to write to another file name.
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -575,6 +575,46 @@ function skipNode(r::XML.Raw, skipnode::String) # separate rows or ssts to speed
     return new, skipped
 end
 
+# Knuth-Morris-Pratt algorithm for substring search on byte arrays
+function kmp_contains(needle::Vector{UInt8}, haystack::Vector{UInt8}) :: Bool
+    m = length(needle)
+    m == 0 && return true
+
+    # Precompute longest prefix-suffix table
+    lps = zeros(Int, m)
+    len = 0
+    i = 2
+    while i <= m
+        if needle[i] == needle[len+1]
+            len += 1
+            lps[i] = len
+            i += 1
+        elseif len > 0
+            len = lps[len]
+        else
+            lps[i] = 0
+            i += 1
+        end
+    end
+
+    # Search
+    i = j = 1
+    while i <= length(haystack)
+        if haystack[i] == needle[j]
+            i += 1
+            j += 1
+            if j > m
+                return true
+            end
+        elseif j > 1
+            j = lps[j-1] + 1
+        else
+            i += 1
+        end
+    end
+    return false
+end
+
 function stream_files(xf::XLSXFile; pass::Int, channel_size::Int=1 << 10)
     Channel{String}(channel_size) do out
         for f in ZipArchives.zip_names(xf.io)
@@ -622,7 +662,12 @@ function load_files!(xf::XLSXFile; pass::Int)
                         rid=get_relationship_id_by_target(wb, file.name)
                         for sheet in wb.sheets
                             if sheet.relationship_id == rid
-                                first_cache_fill!(sheet, XML.LazyNode(file.raw), Threads.nthreads())
+                                if kmp_contains(Vector{UInt8}("t=\"inlineStr\""), file.raw.data)
+                                    nth=1 # single threaded if inlineStrings are present to avoid non-threadsafe access to shared string table
+                                else
+                                    nth=Threads.nthreads() # multi-threaded otherwise
+                                end
+                                first_cache_fill!(sheet, XML.LazyNode(file.raw), nth)
                             end
                         end
                     end

--- a/src/relationship.jl
+++ b/src/relationship.jl
@@ -78,7 +78,7 @@ end
 # Adds new relationship. Returns new generated rId.
 function add_relationship!(wb::Workbook, target::String, _type::String)::String
     xf = get_xlsxfile(wb)
-    !is_writable(xf) && throws(XLSXError("XLSXFile instance is not writable."))
+#    !is_writable(xf) && throw(XLSXError("XLSXFile instance is not writable."))
     local rId::String
 
     let

--- a/src/sst.jl
+++ b/src/sst.jl
@@ -28,19 +28,15 @@ function add_shared_string!(sst::SharedStringTable, str_unformatted::AbstractStr
         # it's already in the table
         return i
     else
-        locked_sst = Locked(sst)
-        withlock(locked_sst) do l
-            push!(l.unformatted_strings, str_unformatted)
-            push!(l.formatted_strings, str_formatted)
-            l.index[str_formatted] = length(sst.formatted_strings)
-            new_index = length(sst.formatted_strings) - 1 # 0-based
-            if new_index != get_shared_string_index(sst, str_formatted)
-                println("sst38 : ",new_index, " ", get_shared_string_index(sst, str_formatted))
-                throw(XLSXError("Inconsistent state after adding a string to the Shared String Table."))
-            end
+        push!(sst.unformatted_strings, str_unformatted)
+        push!(sst.formatted_strings, str_formatted)
+        sst.index[str_formatted] = length(sst.formatted_strings)
+        new_index = length(sst.formatted_strings) - 1 # 0-based
+        if new_index != get_shared_string_index(sst, str_formatted)
+            throw(XLSXError("Inconsistent state after adding a string to the Shared String Table."))
         end
-        return new_index
     end
+    return new_index
 end
 
 # Adds a string to shared string table. Returns the 0-based index of the shared string in the shared string table.

--- a/src/sst.jl
+++ b/src/sst.jl
@@ -20,36 +20,8 @@ function get_shared_string_index(sst::SharedStringTable, str_formatted::Abstract
     end
 
 end
-
-function add_shared_string!(sst::SharedStringTable, str_unformatted::AbstractString, str_formatted::AbstractString) :: Int
-    i = get_shared_string_index(sst, str_formatted)
-    local new_index::Int
-    if i !== nothing
-        # it's already in the table
-        return i
-    else
-        push!(sst.unformatted_strings, str_unformatted)
-        push!(sst.formatted_strings, str_formatted)
-        sst.index[str_formatted] = length(sst.formatted_strings)
-        new_index = length(sst.formatted_strings) - 1 # 0-based
-        if new_index != get_shared_string_index(sst, str_formatted)
-            throw(XLSXError("Inconsistent state after adding a string to the Shared String Table."))
-        end
-    end
-    return new_index
-end
-
-# Adds a string to shared string table. Returns the 0-based index of the shared string in the shared string table.
-function add_shared_string!(wb::Workbook, str_unformatted::AbstractString, str_formatted::AbstractString) :: Int
-#    !is_writable(get_xlsxfile(wb)) && throw(XLSXError("XLSXFile instance is not writable."))
-    if (isempty(str_unformatted) || isempty(str_formatted))
-        throw(XLSXError("Can't add empty string to Shared String Table."))
-    end
-    sst = get_sst(wb)
-
+function create_new_sst(wb::Workbook, sst::SharedStringTable)
     if !sst.is_loaded
-        # if got to this point, the file was opened as template but doesn't have a Shared String Table.
-        # Will create a new one.
         sst.is_loaded = true
 
         # add relationship
@@ -66,8 +38,57 @@ function add_shared_string!(wb::Workbook, str_unformatted::AbstractString, str_f
         push!(ctype_root, override_node)
         init_sst_index(sst)
     end
+end
 
-    return add_shared_string!(sst, str_unformatted, str_formatted)
+function add_to_sst!(sst::SharedStringTable, str_unformatted::AbstractString, str_formatted::AbstractString) :: Int
+    push!(sst.unformatted_strings, str_unformatted)
+    push!(sst.formatted_strings, str_formatted)
+    sst.index[str_formatted] = length(sst.formatted_strings)
+    new_index = length(sst.formatted_strings) - 1 # 0-based
+    if new_index != get_shared_string_index(sst, str_formatted)
+        throw(XLSXError("Inconsistent state after adding a string to the Shared String Table."))
+    end
+    return new_index
+end
+function add_shared_string!(sst::SharedStringTable, str_unformatted::AbstractString, str_formatted::AbstractString; mylock::Union{Nothing,ReentrantLock}=nothing) :: Int
+    i = get_shared_string_index(sst, str_formatted)
+    local new_index::Int
+    if i !== nothing
+        # it's already in the table
+        return i
+    else
+        if isnothing(mylock)
+            new_index = add_to_sst!(sst, str_unformatted, str_formatted)
+        else
+            lock(mylock) do
+                new_index = add_to_sst!(sst, str_unformatted, str_formatted)
+            end
+        end
+    end
+    return new_index
+end
+
+# Adds a string to shared string table. Returns the 0-based index of the shared string in the shared string table.
+function add_shared_string!(wb::Workbook, str_unformatted::AbstractString, str_formatted::AbstractString; mylock::Union{Nothing,ReentrantLock}=nothing) :: Int
+#    !is_writable(get_xlsxfile(wb)) && throw(XLSXError("XLSXFile instance is not writable."))
+    if (isempty(str_unformatted) || isempty(str_formatted))
+        throw(XLSXError("Can't add empty string to Shared String Table."))
+    end
+    sst = get_sst(wb)
+
+        # if got to this point, the file was opened as template but doesn't have a Shared String Table.
+        # Will create a new one.
+    if !sst.is_loaded
+        if isnothing(mylock)
+            create_new_sst(wb, sst)
+        else
+            lock(mylock) do # ensure thread-safety if multiple threads are trying to add inlineStrings
+                create_new_sst(wb, sst)
+            end
+        end
+    end
+    
+    return add_shared_string!(sst, str_unformatted, str_formatted; mylock)
 end
 
 # allow to write cells containing only whitespace characters or with leading or trailing whitespace.

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -351,7 +351,7 @@ by the iterator. The `length(eachrow(sheet))` function therefore
 defines the number of rows that are not entirely empty and will, 
 in any case, only succeed if the worksheet cache is in use.
 """
-function Base.eachrow(ws::Worksheet) :: SheetRowIterator
+function eachrow(ws::Worksheet) :: SheetRowIterator
     if is_cache_enabled(ws)
         if ws.cache === nothing # fill cache if enabled but empty on first use of eachrow iterator
             target_file = get_relationship_target_by_id("xl", get_workbook(ws), ws.relationship_id)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -357,10 +357,10 @@ function Base.eachrow(ws::Worksheet) :: SheetRowIterator
 #            ws.cache = WorksheetCache(ws) # the old way - fill cache incrementally only as far as needed using iterator
             target_file = get_relationship_target_by_id("xl", get_workbook(ws), ws.relationship_id)
             lznode = open_internal_file_stream(get_xlsxfile(ws), target_file)
-            if kmp_contains(Vector{UInt8}("\"inlineStr\""), lznode.raw.data)
-                nth=1 # single threaded if inlineStrings are present to avoid non-threadsafe access to shared string table
+            if isnothing(findfirst(Vector{UInt8}("\"inlineStr\""), lznode.raw.data))
+                nth=Threads.nthreads() # multi-threaded if no inlineStrings are present
             else
-                nth=Threads.nthreads() # multi-threaded otherwise
+                nth=1 # single threaded if inlineStrings are present to avoid non-threadsafe access to shared string table
             end
             first_cache_fill!(ws, lznode, nth) # fill cache if enabled but empty on first use of eachrow iterator
         end

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -159,7 +159,8 @@ function Base.iterate(itr::SheetRowStreamIterator, state::Union{Nothing, SheetRo
 
         elseif XML.nodetype(lznode) == XML.Element && XML.tag(lznode) == "c" # This is a cell
             cell_no += 1
-            cell = Cell(lznode)
+            cell = Cell(lznode, ws)
+            itr.sheet.sst_count += cell.datatype == "s" ? 1 : 0
             if row_number(cell) != current_row
                 throw(XLSXError("Error processing Worksheet $(ws.name): Inconsistent state: expected row number $(current_row), but cell has row number $(row_number(cell))"))
             end
@@ -399,7 +400,7 @@ function process_row(row::XML.LazyNode, handled_attributes::Set{String}, ws::Wor
     sst_count=0
     for c in cells
         if c.tag == "c"
-            cell = Cell(c)
+            cell = Cell(c, ws)
             col_num = column_number(cell)
             if cell.datatype=="s"
                 sst_count += 1
@@ -501,7 +502,7 @@ function match_rows(ws::Worksheet, rows_to_match::Vector{Int})::Vector{SheetRow}
                 cells = XML.children(n)
                 for c in cells
                     if c.tag == "c"
-                        cell = Cell(c)
+                        cell = Cell(c, ws)
                         col_num = column_number(cell)
 
                         # Verify row consistency

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -420,9 +420,10 @@ end
 
 function first_cache_fill!(ws::Worksheet, lznode::XML.LazyNode, nthreads::Int)
     handled_attributes = Set{String}([
-        "r",     # the row number
-        "spans", # the columns the row spans
-        "ht",    # the row height
+        "r",            # the row number
+        "spans",        # the columns the row spans
+        "ht",           # the row height
+        "customHeight"  # flag for when custom height is defined
     ])
     unhandled_attributes = Dict{Int,Dict{String,String}}() # Row number => (name, value)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -553,3 +553,15 @@ struct FileArray <: AbstractVector{UInt8}
     offset::Int64
     len::Int64
 end
+
+mutable struct Locked{T}
+    value::T
+    lock::ReentrantLock
+    Locked(x::T) where {T} = new{T}(x, ReentrantLock())
+end
+
+function withlock(f, obj::Locked)
+    lock(obj.lock) do
+        f(obj.value)
+    end
+end

--- a/src/write.jl
+++ b/src/write.jl
@@ -1281,7 +1281,7 @@ end
 Delete the given worksheet, the worksheet with the given name or the worksheet with the given `sheetId` from its `XLSXFile` 
 (`sheetId` is a 1-based integer representing the order in which worksheet tabs are displayed in Excel).
 
-# note "Caution"
+!!! note "Caution"
     Cells in the other sheets that have references to the deleted sheet will fail when the sheet is deleted.
     The formulae are updated to contain a `#Ref!` error in place of each sheetcell reference.
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6022,6 +6022,32 @@ end
     @test ismissing(sheet["I2"])
     @test ismissing(sheet["J1"])
     @test ismissing(sheet["J2"])
+
+    xf = XLSX.openxlsx(joinpath(data_directory, "inlinestr.xlsx"), mode="rw")
+    XLSX.writexlsx("mydata.xlsx", xf, overwrite=true)
+    xf = XLSX.readxlsx("mydata.xlsx")
+    sheet = xf["Requirements"]
+    @test sheet["A1"] == "NN"
+    @test sheet["A2"] == 1
+    @test sheet["B1"] == "Hierarchy"
+    @test sheet["B2"] == "+"
+    @test ismissing(sheet["C1"])
+    @test ismissing(sheet["C2"])
+    @test sheet["D1"] == "Outline Number"
+    @test sheet["D2"] == "1."
+    @test sheet["E1"] == "ID"
+    @test sheet["E2"] == "RQ11610"
+    @test sheet["F1"] == "Name"
+    @test sheet["F2"] == "requirement"
+    @test sheet["G1"] == "Type"
+    @test sheet["G2"] == "Textual Requirement"
+    @test sheet["H1"] == "Description"
+    @test sheet["H2"] == "test"
+    @test ismissing(sheet["I1"])
+    @test ismissing(sheet["I2"])
+    @test ismissing(sheet["J1"])
+    @test ismissing(sheet["J2"])
+    isfile("mydata.xlsx") && rm("mydata.xlsx")
 end
 
 # issue #299 & 301


### PR DESCRIPTION
Two updates here:

- A 3x speed-up in `writexlsx`
- A fix for #318 

In #315, I reported times for `writexlsx` on a very large Excel file:
```
writexlsx
        This PR:   37.201946 seconds (743.38 M allocations: 37.560 GiB, 25.55% gc time, 27318 lock conflicts, 2.11% compilation time: 13% of which was recompilation)
        v0.10.4:   61.998976 seconds (43.08 M allocations: 3.621 GiB, 2.87% gc time, 0.04% compilation time)
```

Now, this PR speeds this up even further for the same file - by a factor of three:
```
julia> @time XLSX.writexlsx("mytest.xlsx", f, overwrite=true)
 12.832639 seconds (124.75 M allocations: 10.621 GiB, 23.27% gc time, 75846 lock conflicts, 0.24% compilation time: 100% of which was recompilation)
"C:\\Users\\tim\\OneDrive\\Documents\\Julia\\XLSX\\XLSX.jl\\mytest.xlsx"
```
This is achieved by bypassing `XML.write` and passing the LazyNode data (`Vector{UInt8}`) directly to ZipArchives.jl to write to file. This is the same approach as @nhz2 took in #287 but in reverse.

For the fix to #318, I took the approach of converting all inline strings to shared strings. Excel does this anyway (on write), so it seems like the natural solution. The challenge here was to build the writes to the sst table in a thread-safe way.