### PR TITLE
Fix datestamp when creating new workbook

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -84,16 +84,17 @@ newxlsx(sheetname::AbstractString=""; update_timestamp::Bool=true)::XLSXFile = o
 
 function fix_datestamp!(xf::XLSXFile)
     # Fix datestamp in blank.xlsx. It is specified in the file `docProps/core.xml`.
-    # These two dated dictate the created and modified dates shown in Excel file properties
+    # These two dates dictate the created and modified dates shown in Excel file properties
     # and in Windows File Explorer.
     # The values in the file are `2018-05-22T02:41:32Z` and `2018-05-22T02:42:04Z` respectively.
     # Reset them to current date/time.
     f = "docProps/core.xml"
+    time_now=Dates.now(Dates.UTC)
     date_format = Dates.dateformat"yyyy-mm-ddTHH:MM:SSZ"
     i, j = get_idces(xf.data[f], "cp:coreProperties", "dcterms:created")
-    any(isnothing, [i, j]) || (xf.data[f][i][j][1]=Dates.format(Dates.now(Dates.UTC), date_format))
+    any(isnothing, [i, j]) || (xf.data[f][i][j][1]=Dates.format(time_now, date_format))
     i, j = get_idces(xf.data[f], "cp:coreProperties", "dcterms:modified")
-    any(isnothing, [i, j]) || (xf.data[f][i][j][1]=Dates.format(Dates.now(Dates.UTC)+Dates.Second(1), date_format))
+    any(isnothing, [i, j]) || (xf.data[f][i][j][1]=Dates.format(time_now+Dates.Second(1), date_format))
     return nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,7 +181,7 @@ data_directory = joinpath(dirname(pathof(XLSX)), "..", "data")
     end
 
     @testset "Fix timestamp" begin
-        t=Dates.now(Dates.UTC) - Second(1)
+        t=Dates.now(Dates.UTC) - Dates.Second(1)
         xf=XLSX.newxlsx()
         f = "docProps/core.xml"
         date_format = Dates.dateformat"yyyy-mm-ddTHH:MM:SSZ"


### PR DESCRIPTION
File Explorer shows "Date" for any `.xlsx` file newly created by XLSX.jl as "22/05/2018 03:42". It turns out this value is read from the internal `docProps\core.xml` file in the `blank.xlsx` file that is used when a new `XLSXFile` is created.

See this [discussion](https://discourse.julialang.org/t/generating-script-from-julia-incorrect-dates-appearing-in-microsoft-one-drive/134437) on Discourse and this (misplaced) [issue](https://github.com/JuliaIO/ZipArchives.jl/issues/101) on ZipArchives.jl for background.

Updating this internal xml file to `now()` resolves this issue.