### PR TITLE
Lock wb.formulas write in Cell() to fix multithread race

### DIFF
--- a/src/cell.jl
+++ b/src/cell.jl
@@ -240,7 +240,13 @@ function Cell(c::XML.LazyNode, ws::Worksheet, sst_pfx::String; mylock::Union{Ree
                 datatype, value = process_tv(wb, t, v, num_style; mylock)
             elseif tag == "f"
                 f = parse_formula_from_element(wb,child)
-                wb.formulas[SheetCellRef(combine_sheet_ref(ws, ref))] = f
+                if isnothing(mylock)
+                    wb.formulas[SheetCellRef(combine_sheet_ref(ws, ref))] = f
+                else
+                    lock(mylock) do # avoid concurrent writes to wb.formulas from Threads.@spawn workers in first_cache_fill!
+                        wb.formulas[SheetCellRef(combine_sheet_ref(ws, ref))] = f
+                    end
+                end
                 formula = true
             end
         end


### PR DESCRIPTION
Fixes #395.

The formula write in `Cell()` (`src/cell.jl`) ran inside `Threads.@spawn` workers spawned by `first_cache_fill!` (`src/stream.jl`), but the `wb.formulas::Dict` write was unprotected — even though `mylock` was already passed as a kwarg and used by sibling calls (`process_tv`, `add_formatted_string!`).

Concurrent dict writes to `wb.formulas` could collide during `rehash!`, manifesting as `AssertionError: Multiple concurrent writes to Dict detected!` or `UndefRefError: access to undefined reference` on Julia 1.12+ (stricter dict concurrency assertions).

The fix follows the existing pattern from `src/sst.jl`:

```julia
if isnothing(mylock)
    # unlocked op
else
    lock(mylock) do
        # locked op
    end
end
```

## Verification

Using the MRE from #395 (5000 formula cells, `julia --threads=4 repro.jl`, 10 iterations):

- **Before fix**: crashes deterministically on iteration 1
- **After fix**: all 10 iterations pass cleanly

## Test plan

- [x] MRE from #395 passes with `--threads=4` after fix
- [ ] CI on the maintainer's pipeline (Julia versions × platforms)

## Related observation (not part of this fix)

`src/cell.jl:401` (the 7-arg `Cell(wb, ref, t, s, v, m, f)` backward-compatibility constructor) calls `process_tv(wb, t, v, num_style)` without forwarding a `mylock` kwarg — unlike the matching call at line 240 in the main `Cell()` constructor. Current callers (`src/formula.jl:245, :251`, `src/write.jl:714`) are single-threaded write paths, so this isn't part of #395. Flagging it here for consistency in case write paths are ever parallelized in the future.