### PR TITLE
Make the Namespace test's multi-line header expectation line-end-agnostic

### DIFF
--- a/test/test_files/Namespace_tests.jl
+++ b/test/test_files/Namespace_tests.jl
@@ -95,7 +95,7 @@
     end
 
     df = XLSX.readto(joinpath(data_directory, "No-Default_NameSpace2.xlsx"), DataFrames.DataFrame; first_row=3)
-    @test DataFrames.names(df) == String[
+    @test replace.(DataFrames.names(df), "\r\n" => "\n") == String[
         "Stock Code",
         "Name of Securities",
         "Category",
@@ -111,7 +111,7 @@
         "Debt Securities Board Lot (Nominal)",
         "Debt Securities Investor Type",
         "POS Eligible",
-        "Spread Table\r\n1 = Part A\r\n3 = Part B\r\n5 = Part D\r\n4 & 6 = Part E",
+        "Spread Table\n1 = Part A\n3 = Part B\n5 = Part D\n4 & 6 = Part E",
         "Trading Currency",
         "RMB Counter"
         ]


### PR DESCRIPTION
`No-Default_NameSpace2.xlsx` carries literal CR LF bytes inside its multi-line "Spread Table" header cell. XML.jl currently reports them verbatim, and its next release normalizes them to LF per XML 1.0 §2.11 (JuliaData/XML.jl#133) — as conforming readers, Excel's own included, already do. This pins the expectation to the conforming form and normalizes the read names before comparing, so the assertion is green with both current and next XML.jl — verified against registry XML v0.4.6 and against the JuliaData/XML.jl#133 branch, 1897/1897 both ways. The write round-trip assertions just below that block in the same testset (`names(df) == names(df2)` after a `writetable`/re-read) need no change: they compare the two reads to each other, not to a pinned literal, so they hold under either reading.